### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "unrouting",
   "type": "module",
   "version": "0.1.7",
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@11.1.2",
   "description": "",
   "license": "MIT",
   "repository": "unjs/unrouting",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,5 +5,7 @@ packages:
 
 overrides:
   unrouting: 'link:.'
-ignoredBuiltDependencies:
-  - esbuild
+
+allowBuilds:
+  esbuild: false
+  simple-git-hooks: true


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pnpm package manager version to 11.1.2
  * Adjusted workspace build configuration policies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unrouting/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->