### PR TITLE
fix!: support rou3 0.9 route patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "10.6.0",
     "lint-staged": "17.0.5",
     "pkg-pr-new": "0.0.65",
-    "rou3": "0.7.12",
+    "rou3": "0.9.0",
     "simple-git-hooks": "2.13.1",
     "tsdown": "0.21.0",
     "typescript": "6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: 0.0.65
         version: 0.0.65
       rou3:
-        specifier: 0.7.12
-        version: 0.7.12
+        specifier: 0.9.0
+        version: 0.9.0
       simple-git-hooks:
         specifier: 2.13.1
         version: 2.13.1
@@ -2140,8 +2140,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rou3@0.7.12:
-    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+  rou3@0.9.0:
+    resolution: {integrity: sha512-kccB4DcJaSBDjH+ihIjTk9x6FYC8tlrdjL3up/aPZ0msR04zcncfuytynAcvjqFytRHgM3la5O6VtYmTsC/lug==}
 
   scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
@@ -4829,7 +4829,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.3
       '@rolldown/binding-win32-x64-msvc': 1.1.3
 
-  rou3@0.7.12: {}
+  rou3@0.9.0: {}
 
   scslre@0.3.0:
     dependencies:

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -288,13 +288,14 @@ export function toRou3(tree: RouteTree): Rou3Route[] {
     let path = '/'
     for (let segmentIndex = 0; segmentIndex < info.segments.length; segmentIndex++) {
       const segment = info.segments[segmentIndex]
+      const hasPatternToken = segment.some(token => token.type !== 'group' && token.type !== 'static')
       let part = ''
       for (const token of segment) {
         switch (token.type) {
           case 'group':
             break
           case 'static': {
-            part += toRou3StaticSegment(token.value)
+            part += hasPatternToken ? toRou3RegexStaticSegment(token.value) : toRou3StaticSegment(token.value)
             break
           }
           case 'dynamic': {
@@ -311,12 +312,13 @@ export function toRou3(tree: RouteTree): Rou3Route[] {
           }
           case 'catchall': {
             assertTerminalRou3Repeatable(info.segments, segmentIndex, segment, 'catchall')
-            part += token.value ? `**:${sanitizeRou3Param(token.value)}` : '**'
+            // `[...slug]` is zero-or-more; rou3's named `**:slug` does not match an empty tail.
+            part += token.value ? `:${sanitizeRou3Param(token.value)}*` : '**'
             break
           }
           case 'repeatable': {
             assertTerminalRou3Repeatable(info.segments, segmentIndex, segment, 'repeatable')
-            part += token.value ? `:${sanitizeRou3Param(token.value)}+` : '*'
+            part += token.value ? `:${sanitizeRou3Param(token.value)}+` : '**:_'
             break
           }
           case 'optional-repeatable': {
@@ -334,7 +336,8 @@ export function toRou3(tree: RouteTree): Rou3Route[] {
 }
 
 function sanitizeRou3Param(value: string): string {
-  return value.replace(/\./g, '') || '_'
+  const sanitized = value.replace(/\./g, '')
+  return sanitized.replace(/^(\d)/, '_$1') || '_'
 }
 
 const ROU3_STATIC_SEGMENT_ESCAPE_RE = /[:(){}\\]/g
@@ -349,6 +352,24 @@ function toRou3StaticSegment(segment: string): string {
   }
 
   return segment.replace(ROU3_STATIC_SEGMENT_ESCAPE_RE, char => `\\${char}`)
+}
+
+const ROU3_REGEX_STATIC_SAFE_CHAR_RE = /^[\w.-]$/
+
+function toRou3RegexStaticSegment(segment: string): string {
+  let result = ''
+  for (const char of segment) {
+    if (ROU3_REGEX_STATIC_SAFE_CHAR_RE.test(char)) {
+      result += char
+    }
+    else if (char.charCodeAt(0) <= 0x7F) {
+      result += `(?:\\x${char.charCodeAt(0).toString(16).padStart(2, '0').toUpperCase()})`
+    }
+    else {
+      result += escapeStringRegexp(char)
+    }
+  }
+  return result
 }
 
 function assertTerminalRou3Repeatable(segments: ParsedPathSegment[], segmentIndex: number, segment: ParsedPathSegment, type: string): void {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -286,27 +286,44 @@ export function toVueRouter4<const Attrs extends Record<string, string[]> = neve
 export function toRou3(tree: RouteTree): Rou3Route[] {
   return flattenTree(tree).map((info) => {
     let path = '/'
-    for (const segment of info.segments) {
+    for (let segmentIndex = 0; segmentIndex < info.segments.length; segmentIndex++) {
+      const segment = info.segments[segmentIndex]
       let part = ''
       for (const token of segment) {
         switch (token.type) {
           case 'group':
             break
           case 'static': {
-            part += token.value
+            part += toRou3StaticSegment(token.value)
             break
           }
           case 'dynamic': {
-            part += token.value ? `:${token.value}` : '*'
+            part += token.value ? `:${sanitizeRou3Param(token.value)}` : '*'
+            break
+          }
+          case 'optional': {
+            part += token.value
+              ? isOwnRou3PathSegment(segment)
+                ? `:${sanitizeRou3Param(token.value)}?`
+                : `:${sanitizeRou3Param(token.value)}(.*)`
+              : '*'
             break
           }
           case 'catchall': {
-            part += token.value ? `**:${token.value}` : '**'
+            assertTerminalRou3Repeatable(info.segments, segmentIndex, segment, 'catchall')
+            part += token.value ? `:${sanitizeRou3Param(token.value)}*` : '**'
             break
           }
-          case 'optional': throw new TypeError('[unrouting] `toRou3` does not support optional parameters')
-          case 'repeatable': throw new TypeError('[unrouting] `toRou3` does not support repeatable parameters')
-          case 'optional-repeatable': throw new TypeError('[unrouting] `toRou3` does not support optional repeatable parameters')
+          case 'repeatable': {
+            assertTerminalRou3Repeatable(info.segments, segmentIndex, segment, 'repeatable')
+            part += token.value ? `:${sanitizeRou3Param(token.value)}+` : '*'
+            break
+          }
+          case 'optional-repeatable': {
+            assertTerminalRou3Repeatable(info.segments, segmentIndex, segment, 'optional repeatable')
+            part += token.value ? `:${sanitizeRou3Param(token.value)}*` : '**'
+            break
+          }
         }
       }
       if (part)
@@ -314,6 +331,40 @@ export function toRou3(tree: RouteTree): Rou3Route[] {
     }
     return { path, file: info.file }
   })
+}
+
+function sanitizeRou3Param(value: string): string {
+  return value.replace(/\./g, '') || '_'
+}
+
+const ROU3_STATIC_SEGMENT_ESCAPE_RE = /[:(){}\\]/g
+
+function toRou3StaticSegment(segment: string): string {
+  if (segment.includes('*')) {
+    if (segment === '*')
+      return '\\*'
+    if (segment === '**')
+      return '\\*\\*'
+    throw new TypeError(`[unrouting] \`toRou3\` cannot represent static segment "${segment}" because rou3 treats \`*\` as a wildcard`)
+  }
+
+  return segment.replace(ROU3_STATIC_SEGMENT_ESCAPE_RE, char => `\\${char}`)
+}
+
+function assertTerminalRou3Repeatable(segments: ParsedPathSegment[], segmentIndex: number, segment: ParsedPathSegment, type: string): void {
+  if (!isOwnRou3PathSegment(segment))
+    throw new TypeError(`[unrouting] \`toRou3\` only supports ${type} parameters as their own segment`)
+
+  if (segments.slice(segmentIndex + 1).some(hasRou3PathSegment))
+    throw new TypeError(`[unrouting] \`toRou3\` only supports ${type} parameters at the end of a route`)
+}
+
+function isOwnRou3PathSegment(segment: ParsedPathSegment): boolean {
+  return segment.filter(token => token.type !== 'group').length === 1
+}
+
+function hasRou3PathSegment(segment: ParsedPathSegment): boolean {
+  return segment.some(token => token.type !== 'group' && (token.type !== 'static' || token.value))
 }
 
 // --- RegExp ------------------------------------------------------------------

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -311,7 +311,7 @@ export function toRou3(tree: RouteTree): Rou3Route[] {
           }
           case 'catchall': {
             assertTerminalRou3Repeatable(info.segments, segmentIndex, segment, 'catchall')
-            part += token.value ? `:${sanitizeRou3Param(token.value)}*` : '**'
+            part += token.value ? `**:${sanitizeRou3Param(token.value)}` : '**'
             break
           }
           case 'repeatable': {

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -94,8 +94,19 @@ describe('rou3 support', () => {
     const pattern = toRou3(tree(['[...slug].vue']))[0].path
     addRoute(router, 'GET', pattern, { value: pattern })
 
-    expect(pattern).toBe('/**:slug')
+    expect(pattern).toBe('/:slug*')
+    expect(findRoute(router, 'GET', '/')?.data.value).toBe('/:slug*')
     expect(findRoute(router, 'GET', '/file/here/we/go')?.params).toEqual({ slug: 'file/here/we/go' })
+  })
+
+  it('supports nested catchall parameters with an empty tail', () => {
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(tree(['files/[...slug].vue']))[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toBe('/files/:slug*')
+    expect(findRoute(router, 'GET', '/files')?.data.value).toBe('/files/:slug*')
+    expect(findRoute(router, 'GET', '/files/a/b')?.params).toEqual({ slug: 'a/b' })
   })
 
   it('supports optional-repeatable parameters', () => {
@@ -110,6 +121,15 @@ describe('rou3 support', () => {
 
   it('sanitizes dotted rou3 param names', () => {
     expect(toRou3(tree(['[.].vue']))[0].path).toBe('/:_')
+  })
+
+  it('sanitizes leading digit rou3 param names', () => {
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(tree(['prefix-[123].vue']))[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toBe('/prefix-:_123')
+    expect(findRoute(router, 'GET', '/prefix-test')?.params).toEqual({ _123: 'test' })
   })
 
   it('escapes rou3 special characters in static segments', () => {
@@ -138,10 +158,35 @@ describe('rou3 support', () => {
     expect(findRoute(router, 'GET', '/test(name)')?.data.value).toBe('static.vue')
   })
 
+  it('escapes static punctuation in mixed rou3 pattern segments', () => {
+    const cases = {
+      'file:[slug].vue': ['/file:x', { slug: 'x' }],
+      'file+[slug].vue': ['/file+x', { slug: 'x' }],
+      'pre*[slug].vue': ['/pre*x', { slug: 'x' }],
+      'café-[slug].vue': ['/café-x', { slug: 'x' }],
+    }
+
+    for (const [file, [example, params]] of Object.entries(cases)) {
+      const router = createRouter<{ value: string }>()
+      const pattern = toRou3(tree([file]))[0].path
+      addRoute(router, 'GET', pattern, { value: pattern })
+
+      expect(findRoute(router, 'GET', example as string)?.params).toEqual(params)
+    }
+
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(tree(['file+[slug].vue']))[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+    expect(findRoute(router, 'GET', '/fileeeeeex')).toBeUndefined()
+  })
+
   it('throws for rou3 patterns that would over-match', () => {
     expect(() => toRou3(tree(['foo*bar.vue']))).toThrow('cannot represent static segment "foo*bar"')
     expect(() => toRou3(tree(['prefix-[slug]+.vue']))).toThrow('only supports repeatable parameters as their own segment')
+    expect(() => toRou3(tree(['[slug]+/suffix.vue']))).toThrow('only supports repeatable parameters at the end of a route')
+    expect(() => toRou3(tree(['prefix-[...slug].vue']))).toThrow('only supports catchall parameters as their own segment')
     expect(() => toRou3(tree(['[...slug]/suffix.vue']))).toThrow('only supports catchall parameters at the end of a route')
+    expect(() => toRou3(tree(['prefix-[[slug]]+.vue']))).toThrow('only supports optional repeatable parameters as their own segment')
     expect(() => toRou3(tree(['[[slug]]+/suffix.vue']))).toThrow('only supports optional repeatable parameters at the end of a route')
   })
 
@@ -192,7 +237,13 @@ describe('rou3 support', () => {
       file: 'unnamed.vue',
       segments: [[{ type: 'repeatable', value: '' }]],
     }] as any)
-    expect(toRou3(t)[0].path).toEqual('/*')
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(t)[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toEqual('/**:_')
+    expect(findRoute(router, 'GET', '/')?.data.value).toBeUndefined()
+    expect(findRoute(router, 'GET', '/file/here/we/go')?.params).toEqual({ _: 'file/here/we/go' })
   })
 
   it('should use double wildcard for catchall tokens without a name', () => {

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -35,7 +35,7 @@ describe('rou3 support', () => {
           "a1_1a": "file",
         },
         "[b2.2b].vue": {
-          "b2.2b": "file",
+          "b22b": "file",
         },
         "[slug].vue": {
           "slug": "file",
@@ -48,16 +48,69 @@ describe('rou3 support', () => {
     `)
   })
 
-  it('should throw error for optional parameters', () => {
-    expect(() => toRou3(tree(['[[optional]].vue']))).toThrow('[unrouting] `toRou3` does not support optional parameters')
+  it('supports optional parameters', () => {
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(tree(['users/[[id]].vue']))[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toBe('/users/:id?')
+    expect(findRoute(router, 'GET', '/users')?.data.value).toBe('/users/:id?')
+    expect(findRoute(router, 'GET', '/users/123')?.params).toEqual({ id: '123' })
   })
 
-  it('should throw error for repeatable parameters', () => {
-    expect(() => toRou3(tree(['[slug]+.vue']))).toThrow('[unrouting] `toRou3` does not support repeatable parameters')
+  it('supports mixed optional parameters', () => {
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(tree(['optional/prefix-[[opt]].vue']))[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toBe('/optional/prefix-:opt(.*)')
+    expect(findRoute(router, 'GET', '/optional/prefix-')?.params).toEqual({ opt: '' })
+    expect(findRoute(router, 'GET', '/optional/prefix-test')?.params).toEqual({ opt: 'test' })
   })
 
-  it('should throw error for optional-repeatable parameters', () => {
-    expect(() => toRou3(tree(['[[slug]]+.vue']))).toThrow('[unrouting] `toRou3` does not support optional repeatable parameters')
+  it('supports repeatable parameters', () => {
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(tree(['[slug]+.vue']))[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toBe('/:slug+')
+    expect(findRoute(router, 'GET', '/file/here/we/go')?.params).toEqual({ slug: 'file/here/we/go' })
+  })
+
+  it('supports optional-repeatable parameters', () => {
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(tree(['[[slug]]+.vue']))[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toBe('/:slug*')
+    expect(findRoute(router, 'GET', '/')?.data.value).toBe('/:slug*')
+    expect(findRoute(router, 'GET', '/file/here/we/go')?.params).toEqual({ slug: 'file/here/we/go' })
+  })
+
+  it('sanitizes dotted rou3 param names', () => {
+    expect(toRou3(tree(['[.].vue']))[0].path).toBe('/:_')
+  })
+
+  it('escapes rou3 special characters in static segments', () => {
+    const cases = {
+      'test:name.vue': ['/test\\:name', '/test:name'],
+      '{file}.vue': ['/\\{file\\}', '/{file}'],
+      '*.vue': ['/\\*', '/*'],
+      '**.vue': ['/\\*\\*', '/**'],
+    }
+
+    for (const [file, [pattern, example]] of Object.entries(cases)) {
+      const router = createRouter<{ value: string }>()
+      expect(toRou3(tree([file]))[0].path).toBe(pattern)
+      addRoute(router, 'GET', pattern, { value: file })
+      expect(findRoute(router, 'GET', example)?.data.value).toBe(file)
+    }
+  })
+
+  it('throws for rou3 patterns that would over-match', () => {
+    expect(() => toRou3(tree(['foo*bar.vue']))).toThrow('cannot represent static segment "foo*bar"')
+    expect(() => toRou3(tree(['prefix-[slug]+.vue']))).toThrow('only supports repeatable parameters as their own segment')
+    expect(() => toRou3(tree(['[...slug]/suffix.vue']))).toThrow('only supports catchall parameters at the end of a route')
   })
 
   it('should handle group-only segments', () => {
@@ -76,10 +129,34 @@ describe('rou3 support', () => {
     expect(toRou3(t)[0].path).toEqual('/*')
   })
 
+  it('should use wildcard for optional tokens without a name', () => {
+    const t = buildTree([{
+      file: 'unnamed.vue',
+      segments: [[{ type: 'optional', value: '' }]],
+    }] as any)
+    expect(toRou3(t)[0].path).toEqual('/*')
+  })
+
+  it('should use wildcard for repeatable tokens without a name', () => {
+    const t = buildTree([{
+      file: 'unnamed.vue',
+      segments: [[{ type: 'repeatable', value: '' }]],
+    }] as any)
+    expect(toRou3(t)[0].path).toEqual('/*')
+  })
+
   it('should use double wildcard for catchall tokens without a name', () => {
     const t = buildTree([{
       file: 'unnamed.vue',
       segments: [[{ type: 'catchall', value: '' }]],
+    }] as any)
+    expect(toRou3(t)[0].path).toEqual('/**')
+  })
+
+  it('should use double wildcard for optional-repeatable tokens without a name', () => {
+    const t = buildTree([{
+      file: 'unnamed.vue',
+      segments: [[{ type: 'optional-repeatable', value: '' }]],
     }] as any)
     expect(toRou3(t)[0].path).toEqual('/**')
   })

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -77,6 +77,15 @@ describe('rou3 support', () => {
     expect(findRoute(router, 'GET', '/file/here/we/go')?.params).toEqual({ slug: 'file/here/we/go' })
   })
 
+  it('supports catchall parameters', () => {
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(tree(['[...slug].vue']))[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toBe('/**:slug')
+    expect(findRoute(router, 'GET', '/file/here/we/go')?.params).toEqual({ slug: 'file/here/we/go' })
+  })
+
   it('supports optional-repeatable parameters', () => {
     const router = createRouter<{ value: string }>()
     const pattern = toRou3(tree(['[[slug]]+.vue']))[0].path

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -58,6 +58,16 @@ describe('rou3 support', () => {
     expect(findRoute(router, 'GET', '/users/123')?.params).toEqual({ id: '123' })
   })
 
+  it('supports named parameters inside a single segment', () => {
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(tree(['articles/article-[slug].vue']))[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toBe('/articles/article-:slug')
+    expect(findRoute(router, 'GET', '/articles/article-test')?.params).toEqual({ slug: 'test' })
+    expect(findRoute(router, 'GET', '/articles/article-test/extra')).toBeUndefined()
+  })
+
   it('supports mixed optional parameters', () => {
     const router = createRouter<{ value: string }>()
     const pattern = toRou3(tree(['optional/prefix-[[opt]].vue']))[0].path
@@ -66,6 +76,7 @@ describe('rou3 support', () => {
     expect(pattern).toBe('/optional/prefix-:opt(.*)')
     expect(findRoute(router, 'GET', '/optional/prefix-')?.params).toEqual({ opt: '' })
     expect(findRoute(router, 'GET', '/optional/prefix-test')?.params).toEqual({ opt: 'test' })
+    expect(findRoute(router, 'GET', '/optional/prefix-test/extra')).toBeUndefined()
   })
 
   it('supports repeatable parameters', () => {
@@ -75,6 +86,7 @@ describe('rou3 support', () => {
 
     expect(pattern).toBe('/:slug+')
     expect(findRoute(router, 'GET', '/file/here/we/go')?.params).toEqual({ slug: 'file/here/we/go' })
+    expect(findRoute(router, 'GET', '/')).toBeUndefined()
   })
 
   it('supports catchall parameters', () => {
@@ -114,12 +126,23 @@ describe('rou3 support', () => {
       addRoute(router, 'GET', pattern, { value: file })
       expect(findRoute(router, 'GET', example)?.data.value).toBe(file)
     }
+
+    const t = buildTree([{
+      file: 'static.vue',
+      segments: [[{ type: 'static', value: 'test(name)' }]],
+    }] as any)
+    const pattern = toRou3(t)[0].path
+    const router = createRouter<{ value: string }>()
+    expect(pattern).toBe('/test\\(name\\)')
+    addRoute(router, 'GET', pattern, { value: 'static.vue' })
+    expect(findRoute(router, 'GET', '/test(name)')?.data.value).toBe('static.vue')
   })
 
   it('throws for rou3 patterns that would over-match', () => {
     expect(() => toRou3(tree(['foo*bar.vue']))).toThrow('cannot represent static segment "foo*bar"')
     expect(() => toRou3(tree(['prefix-[slug]+.vue']))).toThrow('only supports repeatable parameters as their own segment')
     expect(() => toRou3(tree(['[...slug]/suffix.vue']))).toThrow('only supports catchall parameters at the end of a route')
+    expect(() => toRou3(tree(['[[slug]]+/suffix.vue']))).toThrow('only supports optional repeatable parameters at the end of a route')
   })
 
   it('should handle group-only segments', () => {
@@ -136,6 +159,24 @@ describe('rou3 support', () => {
       segments: [[{ type: 'dynamic', value: '' }]],
     }] as any)
     expect(toRou3(t)[0].path).toEqual('/*')
+  })
+
+  it('should use wildcard for unnamed dynamic tokens inside a single segment', () => {
+    const t = buildTree([{
+      file: 'unnamed.vue',
+      segments: [[
+        { type: 'static', value: 'file-' },
+        { type: 'dynamic', value: '' },
+        { type: 'static', value: '.png' },
+      ]],
+    }] as any)
+    const router = createRouter<{ value: string }>()
+    const pattern = toRou3(t)[0].path
+    addRoute(router, 'GET', pattern, { value: pattern })
+
+    expect(pattern).toEqual('/file-*.png')
+    expect(findRoute(router, 'GET', '/file-icon.png')?.params).toEqual({ 0: 'icon' })
+    expect(findRoute(router, 'GET', '/file-icon/svg.png')).toBeUndefined()
   })
 
   it('should use wildcard for optional tokens without a name', () => {


### PR DESCRIPTION
Related to https://github.com/nuxt/nuxt/pull/35455.

Updates `toRou3()` to emit `rou3@0.9` route patterns for optional, repeatable, optional-repeatable, and catch-all params. It also adds coverage for escaped static route characters.

This rejects page patterns that latest `rou3` would overmatch instead of generating a route with different behavior.

Breaking :warning: : `toRou3()` output now targets `rou3@0.9`. Consumers relying on the old pattern strings or older `rou3` versions should update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded route pattern support for optional, repeatable, and optional-repeatable paths, including mixed and unnamed variants.
  * Improved handling of special route segment patterns for more flexible matching.

* **Bug Fixes**
  * Fixed cases where some route patterns previously failed to convert and now produce valid matching syntax.
  * Improved support for route names containing special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->