### PR TITLE
feat: add `vueRouterToRou3` converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,13 +294,22 @@ interface Rou3Route {
 Convert a compiled Vue Router path string (e.g. a route definition's `path`) into one or more rou3 patterns. Useful when you already have resolved Vue Router routes (not files) and need to feed them to rou3/Nitro, for example when a module rewrites paths at runtime.
 
 ```ts
-function vueRouterToRou3(path: string, options?: VueRouterToRou3Options): string[]
+function vueRouterToRou3(path: string, options?: VueRouterToRou3Options): VueRouterToRou3Result
 
 interface VueRouterToRou3Options {
   /** Expand finite alternation params (`:locale(de|fr)`) into concrete paths. @default true */
   expand?: boolean
   /** Max paths a single input may expand to before falling back to a dynamic param. @default 100 */
   maxExpansions?: number
+  /** Collapse each result into a catch-all glob from its first dynamic segment. @default false */
+  collapse?: boolean
+}
+
+interface VueRouterToRou3Result {
+  /** The converted rou3 patterns. */
+  patterns: string[]
+  /** One entry per lossy or widening conversion step; empty when the conversion is faithful. */
+  issues: VueRouterToRou3Issue[]
 }
 ```
 
@@ -309,14 +318,35 @@ Params carrying a finite alternation regexp are expanded into concrete paths; ot
 ```ts
 import { vueRouterToRou3 } from 'unrouting'
 
-vueRouterToRou3('/:locale(de|fr)/account/verify')
+vueRouterToRou3('/:locale(de|fr)/account/verify').patterns
 // => ['/de/account/verify', '/fr/account/verify']
 
-vueRouterToRou3('/users/:id(\\d+)')
+vueRouterToRou3('/users/:id(\\d+)').patterns
 // => ['/users/:id(\\d+)']
 
-vueRouterToRou3('/:pathMatch(.*)*')
+vueRouterToRou3('/:pathMatch(.*)*').patterns
 // => ['/:pathMatch*']
+```
+
+With `collapse: true`, each path becomes a catch-all glob starting at its first dynamic segment. This exists because some targets (route-rule keys, hosting provider config exports) only understand static prefixes and `**` globs, not `:param` matchers. Enumerable params are still expanded first, so the glob stays as narrow as possible. Note that a path with multiple dynamic params (`/foo/:a/:b`) still collapses to `/foo/**` (with a `collapsed` issue) rather than producing no result.
+
+```ts
+vueRouterToRou3('/products/:id/edit', { collapse: true }).patterns
+// => ['/products/**']
+
+vueRouterToRou3('/:locale(de|fr)/account/:id', { collapse: true }).patterns
+// => ['/de/account/**', '/fr/account/**']
+
+vueRouterToRou3('/static/path', { collapse: true }).patterns
+// => ['/static/path']
+```
+
+Conversions are best-effort: a collapsed catch-all matches more than the original path, repeatable params lose their regexp constraint (rou3 does not enforce them) and huge alternations fall back to plain dynamic params. Every such step is recorded in `issues` so callers can surface them to their users:
+
+```ts
+const { patterns, issues } = vueRouterToRou3('/products/:id', { collapse: true })
+// patterns => ['/products/**']
+// issues => [{ type: 'collapsed', message: 'Collapsed "/products/:id" at segment ":id" into a `**` catch-all, ...' }]
 ```
 
 ### `toRegExp(tree)`

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ interface VueRouterToRou3Options {
 }
 ```
 
-Params carrying a finite alternation regexp are expanded into concrete paths; other custom regexps are dropped because rou3 cannot represent them.
+Params carrying a finite alternation regexp are expanded into concrete paths; other custom regexps are preserved as rou3 param constraints where rou3 enforces them (plain and optional params) and dropped on repeatable params, where rou3 ignores them.
 
 ```ts
 import { vueRouterToRou3 } from 'unrouting'
@@ -313,7 +313,7 @@ vueRouterToRou3('/:locale(de|fr)/account/verify')
 // => ['/de/account/verify', '/fr/account/verify']
 
 vueRouterToRou3('/users/:id(\\d+)')
-// => ['/users/:id']
+// => ['/users/:id(\\d+)']
 
 vueRouterToRou3('/:pathMatch(.*)*')
 // => ['/:pathMatch*']

--- a/README.md
+++ b/README.md
@@ -289,6 +289,36 @@ interface Rou3Route {
 }
 ```
 
+### `vueRouterToRou3(path, options?)`
+
+Convert a compiled Vue Router path string (e.g. a route definition's `path`) into one or more rou3 patterns. Useful when you already have resolved Vue Router routes (not files) and need to feed them to rou3/Nitro, for example when a module rewrites paths at runtime.
+
+```ts
+function vueRouterToRou3(path: string, options?: VueRouterToRou3Options): string[]
+
+interface VueRouterToRou3Options {
+  /** Expand finite alternation params (`:locale(de|fr)`) into concrete paths. @default true */
+  expand?: boolean
+  /** Max paths a single input may expand to before falling back to a dynamic param. @default 100 */
+  maxExpansions?: number
+}
+```
+
+Params carrying a finite alternation regexp are expanded into concrete paths; other custom regexps are dropped because rou3 cannot represent them.
+
+```ts
+import { vueRouterToRou3 } from 'unrouting'
+
+vueRouterToRou3('/:locale(de|fr)/account/verify')
+// => ['/de/account/verify', '/fr/account/verify']
+
+vueRouterToRou3('/users/:id(\\d+)')
+// => ['/users/:id']
+
+vueRouterToRou3('/:pathMatch(.*)*')
+// => ['/:pathMatch*']
+```
+
 ### `toRegExp(tree)`
 
 Emit RegExp matchers from a tree.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ function vueRouterToRou3(path: string, options?: VueRouterToRou3Options): VueRou
 interface VueRouterToRou3Options {
   /** Expand finite alternation params (`:locale(de|fr)`) into concrete paths. @default true */
   expand?: boolean
-  /** Max paths a single input may expand to before falling back to a dynamic param. @default 100 */
+  /** Max paths a single input may expand to before falling back to a dynamic param. Must be a positive integer or a TypeError is thrown. @default 100 */
   maxExpansions?: number
   /** Collapse each result into a catch-all glob from its first dynamic segment. @default false */
   collapse?: boolean
@@ -313,7 +313,7 @@ interface VueRouterToRou3Result {
 }
 ```
 
-Params carrying a finite alternation regexp are expanded into concrete paths; other custom regexps are preserved as rou3 param constraints where rou3 enforces them (plain and optional params) and dropped on repeatable params, where rou3 ignores them.
+Params carrying a finite alternation regexp are expanded into concrete paths; other custom regexps are preserved as rou3 param constraints where rou3 enforces them (plain and optional params). They are dropped on repeatable params (rou3 ignores them there) and when the regexp contains `/` (rou3 splits patterns on slashes and cannot represent it).
 
 ```ts
 import { vueRouterToRou3 } from 'unrouting'

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -388,6 +388,228 @@ function hasRou3PathSegment(segment: ParsedPathSegment): boolean {
   return segment.some(token => token.type !== 'group' && (token.type !== 'static' || token.value))
 }
 
+// --- Vue Router path string → rou3 -------------------------------------------
+
+export interface VueRouterToRou3Options {
+  /**
+   * Expand params whose custom regexp is a finite alternation of literal
+   * values (e.g. `:locale(de|fr)`) into one concrete path per branch.
+   *
+   * When `false`, such params are emitted as a single rou3 dynamic param
+   * (`:locale`) instead of being enumerated.
+   *
+   * @default true
+   */
+  expand?: boolean
+
+  /**
+   * Upper bound on the number of paths a single input may expand to. Once the
+   * cartesian product of enumerable branches would exceed this, expansion is
+   * abandoned and the offending params fall back to dynamic rou3 params.
+   *
+   * @default 100
+   */
+  maxExpansions?: number
+}
+
+interface VueRouterPathToken {
+  type: 'static' | 'param'
+  /** Static text, or the param name (without the leading `:`). */
+  value: string
+  /** Raw regexp source between the parentheses, if the param declared one. */
+  regexp?: string
+  modifier: '' | '?' | '+' | '*'
+}
+
+const VUE_ROUTER_PARAM_NAME_RE = /[\w$]/
+/** Alternation of URL-safe literals, e.g. `de|fr|en-GB`. */
+const ENUMERABLE_ALTERNATION_RE = /^[\w.~-]+(?:\|[\w.~-]+)*$/
+
+/**
+ * Convert a compiled Vue Router path string (e.g. from a route definition's
+ * `path`) into one or more rou3 patterns.
+ *
+ * Params carrying a finite alternation regexp are expanded into concrete
+ * paths, so `/:locale(de|fr)/account/verify` becomes
+ * `['/de/account/verify', '/fr/account/verify']`. Other params degrade to
+ * rou3 dynamic (`:id`), repeatable (`:id+`), optional (`:id?`) or catch-all
+ * (`:id*` / `**`) segments; the custom regexp is dropped because rou3 cannot
+ * represent it.
+ *
+ * @example
+ * vueRouterToRou3('/:locale(de|fr)/account/verify')
+ * // => ['/de/account/verify', '/fr/account/verify']
+ *
+ * @example
+ * vueRouterToRou3('/users/:id(\\d+)')
+ * // => ['/users/:id']
+ */
+export function vueRouterToRou3(path: string, options: VueRouterToRou3Options = {}): string[] {
+  const expand = options.expand ?? true
+  const maxExpansions = options.maxExpansions ?? 100
+
+  const trailingSlash = path.length > 1 && path.endsWith('/')
+  const rawSegments = splitVueRouterSegments(path)
+
+  let variants: string[] = ['']
+  for (const rawSegment of rawSegments) {
+    if (rawSegment === '')
+      continue
+
+    const alternatives = vueRouterSegmentToRou3(rawSegment, expand)
+
+    if (variants.length * alternatives.length > maxExpansions) {
+      const collapsed = vueRouterSegmentToRou3(rawSegment, false)[0]
+      variants = variants.map(prefix => `${prefix}/${collapsed}`)
+      continue
+    }
+
+    const next: string[] = []
+    for (const prefix of variants) {
+      for (const alternative of alternatives)
+        next.push(alternative === '' ? prefix : `${prefix}/${alternative}`)
+    }
+    variants = next
+  }
+
+  return variants.map(v => (v === '' ? '/' : v) + (trailingSlash ? '/' : ''))
+}
+
+/** Split on `/` while ignoring slashes inside a param's `(...)` regexp. */
+function splitVueRouterSegments(path: string): string[] {
+  const segments: string[] = []
+  let current = ''
+  let depth = 0
+  for (let i = 0; i < path.length; i++) {
+    const char = path[i]
+    if (char === '\\') {
+      current += char + (path[i + 1] ?? '')
+      i++
+      continue
+    }
+    if (char === '(')
+      depth++
+    else if (char === ')' && depth > 0)
+      depth--
+    if (char === '/' && depth === 0) {
+      segments.push(current)
+      current = ''
+      continue
+    }
+    current += char
+  }
+  segments.push(current)
+  return segments
+}
+
+function vueRouterSegmentToRou3(segment: string, expand: boolean): string[] {
+  const tokens = parseVueRouterSegment(segment)
+
+  let parts: string[] = ['']
+  for (const token of tokens) {
+    const alternatives = vueRouterTokenToRou3(token, expand)
+    const next: string[] = []
+    for (const prefix of parts) {
+      for (const alternative of alternatives)
+        next.push(prefix + alternative)
+    }
+    parts = next
+  }
+  return parts
+}
+
+function vueRouterTokenToRou3(token: VueRouterPathToken, expand: boolean): string[] {
+  if (token.type === 'static')
+    return [toRou3StaticSegment(token.value)]
+
+  if (
+    expand
+    && token.regexp
+    && (token.modifier === '' || token.modifier === '?')
+    && ENUMERABLE_ALTERNATION_RE.test(token.regexp)
+  ) {
+    const branches = token.regexp.split('|')
+    return token.modifier === '?' ? ['', ...branches] : branches
+  }
+
+  const name = sanitizeRou3Param(token.value)
+  switch (token.modifier) {
+    case '?':
+      return [`:${name}?`]
+    case '+':
+      return [`:${name}+`]
+    case '*':
+      return [`:${name}*`]
+    default:
+      return [`:${name}`]
+  }
+}
+
+function parseVueRouterSegment(segment: string): VueRouterPathToken[] {
+  const tokens: VueRouterPathToken[] = []
+  let staticBuffer = ''
+  let i = 0
+
+  const flushStatic = () => {
+    if (staticBuffer) {
+      tokens.push({ type: 'static', value: staticBuffer, modifier: '' })
+      staticBuffer = ''
+    }
+  }
+
+  while (i < segment.length) {
+    const char = segment[i]
+
+    if (char === '\\' && segment[i + 1] === ':') {
+      staticBuffer += ':'
+      i += 2
+      continue
+    }
+
+    if (char !== ':') {
+      staticBuffer += char
+      i++
+      continue
+    }
+
+    flushStatic()
+    i++
+
+    let name = ''
+    while (i < segment.length && VUE_ROUTER_PARAM_NAME_RE.test(segment[i])) {
+      name += segment[i]
+      i++
+    }
+
+    let regexp: string | undefined
+    if (segment[i] === '(') {
+      let depth = 0
+      let source = ''
+      do {
+        const inner = segment[i]
+        if (inner === '(')
+          depth++
+        else if (inner === ')')
+          depth--
+        source += inner
+        i++
+      } while (i < segment.length && depth > 0)
+      regexp = source.slice(1, -1)
+    }
+
+    let modifier: VueRouterPathToken['modifier'] = ''
+    if (segment[i] === '?' || segment[i] === '+' || segment[i] === '*') {
+      modifier = segment[i] as VueRouterPathToken['modifier']
+      i++
+    }
+
+    tokens.push({ type: 'param', value: name, regexp, modifier })
+  }
+
+  flushStatic()
+  return tokens
+}
+
 // --- RegExp ------------------------------------------------------------------
 
 export function toRegExp(tree: RouteTree): RegExpRoute[] {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -439,8 +439,10 @@ export interface VueRouterToRou3Issue {
   /**
    * - `collapsed`: the path (or its remainder) was replaced with a `**`
    *   catch-all, which also matches nested paths the original did not.
-   * - `dropped-regexp`: a repeatable param's custom regexp was dropped
-   *   because rou3 does not enforce constraints on repeatable params.
+   * - `dropped-regexp`: a param's custom regexp was dropped, either because
+   *   the param is repeatable (rou3 does not enforce constraints there) or
+   *   because the regexp contains `/` (rou3 splits patterns on slashes and
+   *   cannot represent it).
    * - `max-expansions`: enumerating an alternation was abandoned because it
    *   would exceed `maxExpansions`; a dynamic param was emitted instead.
    */
@@ -472,8 +474,9 @@ const ENUMERABLE_ALTERNATION_RE = /^[\w.~-]+(?:\|[\w.~-]+)*$/
  * `['/de/account/verify', '/fr/account/verify']`. Other params degrade to
  * rou3 dynamic (`:id`), repeatable (`:id+`), optional (`:id?`) or catch-all
  * (`:id*` / `**`) segments. Custom regexps are preserved as rou3 param
- * constraints where rou3 enforces them (plain and optional params); rou3
- * ignores constraints on repeatable params, so they are dropped there.
+ * constraints where rou3 enforces them (plain and optional params); they are
+ * dropped on repeatable params (rou3 ignores them there) and when the regexp
+ * contains `/` (rou3 cannot represent it).
  *
  * Any lossy or widening step taken along the way is recorded in `issues`, so
  * callers can surface risky conversions to their users.
@@ -489,6 +492,8 @@ const ENUMERABLE_ALTERNATION_RE = /^[\w.~-]+(?:\|[\w.~-]+)*$/
 export function vueRouterToRou3(path: string, options: VueRouterToRou3Options = {}): VueRouterToRou3Result {
   const expand = options.expand ?? true
   const maxExpansions = options.maxExpansions ?? 100
+  if (!Number.isInteger(maxExpansions) || maxExpansions < 1)
+    throw new TypeError(`[unrouting] \`maxExpansions\` must be a positive integer (got ${maxExpansions})`)
   const collapse = options.collapse ?? false
 
   const issues: VueRouterToRou3Issue[] = []
@@ -628,7 +633,21 @@ function vueRouterTokenToRou3(token: VueRouterPathToken, expand: boolean, report
   const name = sanitizeRou3Param(token.value)
   // rou3 only enforces `(regexp)` constraints on plain and optional params;
   // repeatable params silently ignore them, so no point emitting them there.
-  const constraint = token.regexp && (token.modifier === '' || token.modifier === '?') ? `(${token.regexp})` : ''
+  // Constraints containing `/` are dropped too: rou3 splits patterns on
+  // slashes before parsing params, producing an invalid regexp.
+  let constraint = ''
+  if (token.regexp && (token.modifier === '' || token.modifier === '?')) {
+    if (token.regexp.includes('/')) {
+      report?.({
+        type: 'dropped-regexp',
+        param: token.value,
+        message: `Dropped custom regexp "(${token.regexp})" on param ":${token.value}" because rou3 cannot represent constraints containing "/"`,
+      })
+    }
+    else {
+      constraint = `(${token.regexp})`
+    }
+  }
   switch (token.modifier) {
     case '?':
       return [`:${name}${constraint}?`]

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -433,8 +433,9 @@ const ENUMERABLE_ALTERNATION_RE = /^[\w.~-]+(?:\|[\w.~-]+)*$/
  * paths, so `/:locale(de|fr)/account/verify` becomes
  * `['/de/account/verify', '/fr/account/verify']`. Other params degrade to
  * rou3 dynamic (`:id`), repeatable (`:id+`), optional (`:id?`) or catch-all
- * (`:id*` / `**`) segments; the custom regexp is dropped because rou3 cannot
- * represent it.
+ * (`:id*` / `**`) segments. Custom regexps are preserved as rou3 param
+ * constraints where rou3 enforces them (plain and optional params); rou3
+ * ignores constraints on repeatable params, so they are dropped there.
  *
  * @example
  * vueRouterToRou3('/:locale(de|fr)/account/verify')
@@ -442,7 +443,7 @@ const ENUMERABLE_ALTERNATION_RE = /^[\w.~-]+(?:\|[\w.~-]+)*$/
  *
  * @example
  * vueRouterToRou3('/users/:id(\\d+)')
- * // => ['/users/:id']
+ * // => ['/users/:id(\\d+)']
  */
 export function vueRouterToRou3(path: string, options: VueRouterToRou3Options = {}): string[] {
   const expand = options.expand ?? true
@@ -456,7 +457,7 @@ export function vueRouterToRou3(path: string, options: VueRouterToRou3Options = 
     if (rawSegment === '')
       continue
 
-    const alternatives = vueRouterSegmentToRou3(rawSegment, expand)
+    const alternatives = vueRouterSegmentToRou3(rawSegment, expand, maxExpansions)
 
     if (variants.length * alternatives.length > maxExpansions) {
       const collapsed = vueRouterSegmentToRou3(rawSegment, false)[0]
@@ -502,12 +503,14 @@ function splitVueRouterSegments(path: string): string[] {
   return segments
 }
 
-function vueRouterSegmentToRou3(segment: string, expand: boolean): string[] {
+function vueRouterSegmentToRou3(segment: string, expand: boolean, maxExpansions = Number.POSITIVE_INFINITY): string[] {
   const tokens = parseVueRouterSegment(segment)
 
   let parts: string[] = ['']
   for (const token of tokens) {
-    const alternatives = vueRouterTokenToRou3(token, expand)
+    let alternatives = vueRouterTokenToRou3(token, expand)
+    if (parts.length * alternatives.length > maxExpansions)
+      alternatives = vueRouterTokenToRou3(token, false)
     const next: string[] = []
     for (const prefix of parts) {
       for (const alternative of alternatives)
@@ -533,15 +536,18 @@ function vueRouterTokenToRou3(token: VueRouterPathToken, expand: boolean): strin
   }
 
   const name = sanitizeRou3Param(token.value)
+  // rou3 only enforces `(regexp)` constraints on plain and optional params;
+  // repeatable params silently ignore them, so no point emitting them there.
+  const constraint = token.regexp && (token.modifier === '' || token.modifier === '?') ? `(${token.regexp})` : ''
   switch (token.modifier) {
     case '?':
-      return [`:${name}?`]
+      return [`:${name}${constraint}?`]
     case '+':
       return [`:${name}+`]
     case '*':
       return [`:${name}*`]
     default:
-      return [`:${name}`]
+      return [`:${name}${constraint}`]
   }
 }
 
@@ -587,6 +593,11 @@ function parseVueRouterSegment(segment: string): VueRouterPathToken[] {
       let source = ''
       do {
         const inner = segment[i]
+        if (inner === '\\') {
+          source += inner + (segment[i + 1] ?? '')
+          i += 2
+          continue
+        }
         if (inner === '(')
           depth++
         else if (inner === ')')

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -410,6 +410,44 @@ export interface VueRouterToRou3Options {
    * @default 100
    */
   maxExpansions?: number
+
+  /**
+   * Collapse each resulting path into a catch-all glob starting at its first
+   * dynamic segment, e.g. `/products/:id/edit` becomes `['/products/**']`.
+   * Enumerable params are still expanded first (subject to `expand`), so
+   * `/:locale(en|nl)/account` becomes `['/en/**', '/nl/**']`. Useful for
+   * deriving route-rule keys or region prefixes rather than faithful matchers.
+   *
+   * @default false
+   */
+  collapse?: boolean
+}
+
+export interface VueRouterToRou3Result {
+  /** The converted rou3 patterns. */
+  patterns: string[]
+  /**
+   * One entry per lossy or widening step taken during conversion, e.g. a
+   * collapsed catch-all, a dropped regexp or an abandoned expansion. Empty
+   * when the conversion is faithful. Lets callers surface risky conversions
+   * to their users.
+   */
+  issues: VueRouterToRou3Issue[]
+}
+
+export interface VueRouterToRou3Issue {
+  /**
+   * - `collapsed`: the path (or its remainder) was replaced with a `**`
+   *   catch-all, which also matches nested paths the original did not.
+   * - `dropped-regexp`: a repeatable param's custom regexp was dropped
+   *   because rou3 does not enforce constraints on repeatable params.
+   * - `max-expansions`: enumerating an alternation was abandoned because it
+   *   would exceed `maxExpansions`; a dynamic param was emitted instead.
+   */
+  type: 'collapsed' | 'dropped-regexp' | 'max-expansions'
+  /** The param name involved, if the issue concerns a single param. */
+  param?: string
+  message: string
 }
 
 interface VueRouterPathToken {
@@ -437,17 +475,24 @@ const ENUMERABLE_ALTERNATION_RE = /^[\w.~-]+(?:\|[\w.~-]+)*$/
  * constraints where rou3 enforces them (plain and optional params); rou3
  * ignores constraints on repeatable params, so they are dropped there.
  *
+ * Any lossy or widening step taken along the way is recorded in `issues`, so
+ * callers can surface risky conversions to their users.
+ *
  * @example
- * vueRouterToRou3('/:locale(de|fr)/account/verify')
+ * vueRouterToRou3('/:locale(de|fr)/account/verify').patterns
  * // => ['/de/account/verify', '/fr/account/verify']
  *
  * @example
- * vueRouterToRou3('/users/:id(\\d+)')
+ * vueRouterToRou3('/users/:id(\\d+)').patterns
  * // => ['/users/:id(\\d+)']
  */
-export function vueRouterToRou3(path: string, options: VueRouterToRou3Options = {}): string[] {
+export function vueRouterToRou3(path: string, options: VueRouterToRou3Options = {}): VueRouterToRou3Result {
   const expand = options.expand ?? true
   const maxExpansions = options.maxExpansions ?? 100
+  const collapse = options.collapse ?? false
+
+  const issues: VueRouterToRou3Issue[] = []
+  const report = (issue: VueRouterToRou3Issue) => issues.push(issue)
 
   const trailingSlash = path.length > 1 && path.endsWith('/')
   const rawSegments = splitVueRouterSegments(path)
@@ -457,10 +502,27 @@ export function vueRouterToRou3(path: string, options: VueRouterToRou3Options = 
     if (rawSegment === '')
       continue
 
-    const alternatives = vueRouterSegmentToRou3(rawSegment, expand, maxExpansions)
+    // In collapse mode token-level issues are irrelevant: any segment that
+    // could produce one is dynamic and gets replaced by `**` wholesale.
+    const alternatives = vueRouterSegmentToRou3(rawSegment, expand, maxExpansions, collapse ? undefined : report)
+    const overflows = variants.length * alternatives.length > maxExpansions
 
-    if (variants.length * alternatives.length > maxExpansions) {
+    if (collapse && (overflows || alternatives.some(alternative => !isStaticRou3Segment(alternative)))) {
+      const params = parseVueRouterSegment(rawSegment).filter(token => token.type === 'param')
+      report({
+        type: 'collapsed',
+        param: params.length === 1 ? params[0]!.value : undefined,
+        message: `Collapsed "${path}" at segment "${rawSegment}" into a \`**\` catch-all, which also matches nested paths`,
+      })
+      return { patterns: variants.map(prefix => `${prefix}/**`), issues }
+    }
+
+    if (overflows) {
       const collapsed = vueRouterSegmentToRou3(rawSegment, false)[0]
+      report({
+        type: 'max-expansions',
+        message: `Expanding segment "${rawSegment}" of "${path}" would exceed maxExpansions (${maxExpansions}); emitted "${collapsed}" instead`,
+      })
       variants = variants.map(prefix => `${prefix}/${collapsed}`)
       continue
     }
@@ -473,7 +535,21 @@ export function vueRouterToRou3(path: string, options: VueRouterToRou3Options = 
     variants = next
   }
 
-  return variants.map(v => (v === '' ? '/' : v) + (trailingSlash ? '/' : ''))
+  return { patterns: variants.map(v => (v === '' ? '/' : v) + (trailingSlash ? '/' : '')), issues }
+}
+
+/** `true` if the emitted segment contains no unescaped rou3 syntax (`:`, `*`). */
+function isStaticRou3Segment(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i]
+    if (char === '\\') {
+      i++
+      continue
+    }
+    if (char === ':' || char === '*')
+      return false
+  }
+  return true
 }
 
 /** Split on `/` while ignoring slashes inside a param's `(...)` regexp. */
@@ -503,14 +579,20 @@ function splitVueRouterSegments(path: string): string[] {
   return segments
 }
 
-function vueRouterSegmentToRou3(segment: string, expand: boolean, maxExpansions = Number.POSITIVE_INFINITY): string[] {
+function vueRouterSegmentToRou3(segment: string, expand: boolean, maxExpansions = Number.POSITIVE_INFINITY, report?: (issue: VueRouterToRou3Issue) => void): string[] {
   const tokens = parseVueRouterSegment(segment)
 
   let parts: string[] = ['']
   for (const token of tokens) {
-    let alternatives = vueRouterTokenToRou3(token, expand)
-    if (parts.length * alternatives.length > maxExpansions)
+    let alternatives = vueRouterTokenToRou3(token, expand, report)
+    if (parts.length * alternatives.length > maxExpansions) {
       alternatives = vueRouterTokenToRou3(token, false)
+      report?.({
+        type: 'max-expansions',
+        param: token.value,
+        message: `Expanding param ":${token.value}" in segment "${segment}" would exceed maxExpansions (${maxExpansions}); emitted "${alternatives[0]}" instead`,
+      })
+    }
     const next: string[] = []
     for (const prefix of parts) {
       for (const alternative of alternatives)
@@ -521,9 +603,17 @@ function vueRouterSegmentToRou3(segment: string, expand: boolean, maxExpansions 
   return parts
 }
 
-function vueRouterTokenToRou3(token: VueRouterPathToken, expand: boolean): string[] {
+function vueRouterTokenToRou3(token: VueRouterPathToken, expand: boolean, report?: (issue: VueRouterToRou3Issue) => void): string[] {
   if (token.type === 'static')
     return [toRou3StaticSegment(token.value)]
+
+  if (token.regexp && token.regexp !== '.*' && (token.modifier === '+' || token.modifier === '*')) {
+    report?.({
+      type: 'dropped-regexp',
+      param: token.value,
+      message: `Dropped custom regexp "(${token.regexp})" on repeatable param ":${token.value}${token.modifier}" because rou3 does not enforce constraints on repeatable params`,
+    })
+  }
 
   if (
     expand

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type { InferAttrs, RegExpRoute, Rou3Route, ToVueRouterSegmentOptions, VueRoute, VueRouterEmitOptions, VueRouterToRou3Options } from './converters'
+export type { InferAttrs, RegExpRoute, Rou3Route, ToVueRouterSegmentOptions, VueRoute, VueRouterEmitOptions, VueRouterToRou3Issue, VueRouterToRou3Options, VueRouterToRou3Result } from './converters'
 export { toRegExp, toRou3, toVueRouter4, toVueRouterPath, toVueRouterSegment, vueRouterToRou3 } from './converters'
 
 export type { CompiledParsePath, ParsedPath, ParsedPathSegment, ParsedPathSegmentToken, ParsePathOptions, SegmentType } from './parse'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export type { InferAttrs, RegExpRoute, Rou3Route, ToVueRouterSegmentOptions, VueRoute, VueRouterEmitOptions } from './converters'
-export { toRegExp, toRou3, toVueRouter4, toVueRouterPath, toVueRouterSegment } from './converters'
+export type { InferAttrs, RegExpRoute, Rou3Route, ToVueRouterSegmentOptions, VueRoute, VueRouterEmitOptions, VueRouterToRou3Options } from './converters'
+export { toRegExp, toRou3, toVueRouter4, toVueRouterPath, toVueRouterSegment, vueRouterToRou3 } from './converters'
 
 export type { CompiledParsePath, ParsedPath, ParsedPathSegment, ParsedPathSegmentToken, ParsePathOptions, SegmentType } from './parse'
 export { compileParsePath, parsePath, parseSegment } from './parse'

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -1,7 +1,7 @@
 import { addRoute, createRouter, findRoute } from 'rou3'
 import { describe, expect, it } from 'vitest'
 import { createMemoryHistory, createRouter as createVueRouter } from 'vue-router'
-import { addFile, buildTree, compileParsePath, isPageNode, parsePath, parseSegment, removeFile, toRegExp, toRou3, toVueRouter4, toVueRouterPath, toVueRouterSegment, walkTree } from '../../src'
+import { addFile, buildTree, compileParsePath, isPageNode, parsePath, parseSegment, removeFile, toRegExp, toRou3, toVueRouter4, toVueRouterPath, toVueRouterSegment, vueRouterToRou3, walkTree } from '../../src'
 
 /** buildTree shorthand — accepts raw strings */
 const tree = (paths: string[]) => buildTree(paths)
@@ -264,6 +264,77 @@ describe('rou3 support', () => {
 
   it('should handle empty segments', () => {
     expect(toRou3(tree(['file//index.vue']))[0].path).toEqual('/file')
+  })
+})
+
+describe('vueRouterToRou3', () => {
+  it('expands enumerable alternation params into concrete paths', () => {
+    expect(vueRouterToRou3('/:locale(de|fr)/account/verify')).toEqual([
+      '/de/account/verify',
+      '/fr/account/verify',
+    ])
+  })
+
+  it('expanded paths resolve against rou3', () => {
+    const router = createRouter<{ value: string }>()
+    for (const path of vueRouterToRou3('/:locale(de|fr)/account/verify'))
+      addRoute(router, 'GET', path, { value: path })
+
+    expect(findRoute(router, 'GET', '/de/account/verify')?.data.value).toBe('/de/account/verify')
+    expect(findRoute(router, 'GET', '/fr/account/verify')?.data.value).toBe('/fr/account/verify')
+    expect(findRoute(router, 'GET', '/es/account/verify')).toBeUndefined()
+  })
+
+  it('handles the cartesian product of multiple enumerable params', () => {
+    expect(vueRouterToRou3('/:locale(de|fr)/blog/:category(tech|life)')).toEqual([
+      '/de/blog/tech',
+      '/de/blog/life',
+      '/fr/blog/tech',
+      '/fr/blog/life',
+    ])
+  })
+
+  it('treats an optional enumerable param as an extra empty branch', () => {
+    expect(vueRouterToRou3('/:locale(de|fr)?/home')).toEqual([
+      '/home',
+      '/de/home',
+      '/fr/home',
+    ])
+  })
+
+  it('drops non-enumerable custom regexps and keeps the dynamic param', () => {
+    expect(vueRouterToRou3('/users/:id(\\d+)')).toEqual(['/users/:id'])
+    expect(vueRouterToRou3('/articles/article-:slug([^/]+)')).toEqual(['/articles/article-:slug'])
+  })
+
+  it('maps param modifiers to rou3 equivalents', () => {
+    expect(vueRouterToRou3('/:id?')).toEqual(['/:id?'])
+    expect(vueRouterToRou3('/:slug+')).toEqual(['/:slug+'])
+    expect(vueRouterToRou3('/:pathMatch(.*)*')).toEqual(['/:pathMatch*'])
+  })
+
+  it('preserves plain and trailing-slash paths', () => {
+    expect(vueRouterToRou3('/')).toEqual(['/'])
+    expect(vueRouterToRou3('/static/path/')).toEqual(['/static/path/'])
+  })
+
+  it('treats an escaped colon as a literal', () => {
+    expect(vueRouterToRou3('/foo\\:bar')).toEqual(['/foo\\:bar'])
+    expect(vueRouterToRou3('/foo\\')).toEqual(['/foo\\\\'])
+  })
+
+  it('can disable expansion', () => {
+    expect(vueRouterToRou3('/:locale(de|fr)/account', { expand: false })).toEqual([
+      '/:locale/account',
+    ])
+  })
+
+  it('falls back to a dynamic param when expansion would exceed the limit', () => {
+    expect(vueRouterToRou3('/:a(a|b|c)/:b(d|e|f)', { maxExpansions: 4 })).toEqual([
+      '/a/:b',
+      '/b/:b',
+      '/c/:b',
+    ])
   })
 })
 

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -268,8 +268,10 @@ describe('rou3 support', () => {
 })
 
 describe('vueRouterToRou3', () => {
+  const patterns = (path: string, options?: Parameters<typeof vueRouterToRou3>[1]) => vueRouterToRou3(path, options).patterns
+
   it('expands enumerable alternation params into concrete paths', () => {
-    expect(vueRouterToRou3('/:locale(de|fr)/account/verify')).toEqual([
+    expect(patterns('/:locale(de|fr)/account/verify')).toEqual([
       '/de/account/verify',
       '/fr/account/verify',
     ])
@@ -277,7 +279,7 @@ describe('vueRouterToRou3', () => {
 
   it('expanded paths resolve against rou3', () => {
     const router = createRouter<{ value: string }>()
-    for (const path of vueRouterToRou3('/:locale(de|fr)/account/verify'))
+    for (const path of patterns('/:locale(de|fr)/account/verify'))
       addRoute(router, 'GET', path, { value: path })
 
     expect(findRoute(router, 'GET', '/de/account/verify')?.data.value).toBe('/de/account/verify')
@@ -286,7 +288,7 @@ describe('vueRouterToRou3', () => {
   })
 
   it('handles the cartesian product of multiple enumerable params', () => {
-    expect(vueRouterToRou3('/:locale(de|fr)/blog/:category(tech|life)')).toEqual([
+    expect(patterns('/:locale(de|fr)/blog/:category(tech|life)')).toEqual([
       '/de/blog/tech',
       '/de/blog/life',
       '/fr/blog/tech',
@@ -295,7 +297,7 @@ describe('vueRouterToRou3', () => {
   })
 
   it('treats an optional enumerable param as an extra empty branch', () => {
-    expect(vueRouterToRou3('/:locale(de|fr)?/home')).toEqual([
+    expect(patterns('/:locale(de|fr)?/home')).toEqual([
       '/home',
       '/de/home',
       '/fr/home',
@@ -303,41 +305,75 @@ describe('vueRouterToRou3', () => {
   })
 
   it('maps param modifiers to rou3 equivalents', () => {
-    expect(vueRouterToRou3('/:id?')).toEqual(['/:id?'])
-    expect(vueRouterToRou3('/:slug+')).toEqual(['/:slug+'])
-    expect(vueRouterToRou3('/:pathMatch(.*)*')).toEqual(['/:pathMatch*'])
+    expect(patterns('/:id?')).toEqual(['/:id?'])
+    expect(patterns('/:slug+')).toEqual(['/:slug+'])
+    expect(patterns('/:pathMatch(.*)*')).toEqual(['/:pathMatch*'])
   })
 
   it('preserves non-enumerable custom regexps as rou3 constraints', () => {
-    expect(vueRouterToRou3('/users/:id(\\d+)')).toEqual(['/users/:id(\\d+)'])
-    expect(vueRouterToRou3('/users/:id(\\d+)?')).toEqual(['/users/:id(\\d+)?'])
-    expect(vueRouterToRou3('/articles/article-:slug([^/]+)')).toEqual(['/articles/article-:slug([^/]+)'])
-    expect(vueRouterToRou3('/repeat/:id(\\d+)+')).toEqual(['/repeat/:id+'])
+    expect(patterns('/users/:id(\\d+)')).toEqual(['/users/:id(\\d+)'])
+    expect(patterns('/users/:id(\\d+)?')).toEqual(['/users/:id(\\d+)?'])
+    expect(patterns('/articles/article-:slug([^/]+)')).toEqual(['/articles/article-:slug([^/]+)'])
+    expect(patterns('/repeat/:id(\\d+)+')).toEqual(['/repeat/:id+'])
   })
 
   it('handles escaped parentheses inside a custom regexp', () => {
-    expect(vueRouterToRou3('/:custom(a\\(b)/tail')).toEqual(['/:custom(a\\(b)/tail'])
-    expect(vueRouterToRou3('/:x(a\\')).toEqual(['/a'])
+    expect(patterns('/:custom(a\\(b)/tail')).toEqual(['/:custom(a\\(b)/tail'])
+    expect(patterns('/:x(a\\')).toEqual(['/a'])
   })
 
   it('preserves plain and trailing-slash paths', () => {
-    expect(vueRouterToRou3('/')).toEqual(['/'])
-    expect(vueRouterToRou3('/static/path/')).toEqual(['/static/path/'])
+    expect(patterns('/')).toEqual(['/'])
+    expect(patterns('/static/path/')).toEqual(['/static/path/'])
   })
 
   it('treats an escaped colon as a literal', () => {
-    expect(vueRouterToRou3('/foo\\:bar')).toEqual(['/foo\\:bar'])
-    expect(vueRouterToRou3('/foo\\')).toEqual(['/foo\\\\'])
+    expect(patterns('/foo\\:bar')).toEqual(['/foo\\:bar'])
+    expect(patterns('/foo\\')).toEqual(['/foo\\\\'])
+  })
+
+  it('collapses to catch-all globs from the first dynamic segment', () => {
+    expect(patterns('/products/:id', { collapse: true })).toEqual(['/products/**'])
+    expect(patterns('/products/:id/edit', { collapse: true })).toEqual(['/products/**'])
+    expect(patterns('/blog/:a/:b', { collapse: true })).toEqual(['/blog/**'])
+    expect(patterns('/article-:slug/edit', { collapse: true })).toEqual(['/**'])
+    expect(patterns('/static/path', { collapse: true })).toEqual(['/static/path'])
+    expect(patterns('/static/path/', { collapse: true })).toEqual(['/static/path/'])
+    expect(patterns('/', { collapse: true })).toEqual(['/'])
+    expect(patterns('/foo\\:bar', { collapse: true })).toEqual(['/foo\\:bar'])
+  })
+
+  it('expands enumerable params before collapsing', () => {
+    expect(patterns('/:locale(de|fr)/account', { collapse: true })).toEqual(['/de/account', '/fr/account'])
+    expect(patterns('/:locale(de|fr)/account/:id', { collapse: true })).toEqual(['/de/account/**', '/fr/account/**'])
+    expect(patterns('/:locale(de|fr)/account', { collapse: true, expand: false })).toEqual(['/**'])
+    expect(patterns('/:a(a|b|c)/:b', { collapse: true, maxExpansions: 2 })).toEqual(['/**'])
+  })
+
+  it('reports risky conversions as issues', () => {
+    const issues = (path: string, options?: Parameters<typeof vueRouterToRou3>[1]) =>
+      vueRouterToRou3(path, options).issues.map(issue => issue.type)
+
+    expect(issues('/products/:id', { collapse: true })).toEqual(['collapsed'])
+    expect(vueRouterToRou3('/products/:id', { collapse: true }).issues[0]!.param).toBe('id')
+    expect(vueRouterToRou3('/blog/:a-:b', { collapse: true }).issues[0]!.param).toBeUndefined()
+    expect(issues('/repeat/:id(\\d+)+')).toEqual(['dropped-regexp'])
+    expect(issues('/:pathMatch(.*)*')).toEqual([])
+    expect(issues('/:a(a|b|c)/:b(d|e|f)', { maxExpansions: 4 })).toEqual(['max-expansions'])
+    expect(issues('/:a(a|b)-:b(c|d)', { maxExpansions: 2 })).toEqual(['max-expansions'])
+    expect(issues('/de/account/verify')).toEqual([])
+    expect(issues('/:locale(de|fr)/account')).toEqual([])
+    expect(issues('/:locale(de|fr)/account', { collapse: true })).toEqual([])
   })
 
   it('can disable expansion', () => {
-    expect(vueRouterToRou3('/:locale(de|fr)/account', { expand: false })).toEqual([
+    expect(patterns('/:locale(de|fr)/account', { expand: false })).toEqual([
       '/:locale(de|fr)/account',
     ])
   })
 
   it('falls back to a constrained param when expansion would exceed the limit', () => {
-    expect(vueRouterToRou3('/:a(a|b|c)/:b(d|e|f)', { maxExpansions: 4 })).toEqual([
+    expect(patterns('/:a(a|b|c)/:b(d|e|f)', { maxExpansions: 4 })).toEqual([
       '/a/:b(d|e|f)',
       '/b/:b(d|e|f)',
       '/c/:b(d|e|f)',
@@ -345,7 +381,7 @@ describe('vueRouterToRou3', () => {
   })
 
   it('bounds expansion of multiple params within a single segment', () => {
-    expect(vueRouterToRou3('/:a(a|b)-:b(c|d)-:c(e|f)', { maxExpansions: 4 })).toEqual([
+    expect(patterns('/:a(a|b)-:b(c|d)-:c(e|f)', { maxExpansions: 4 })).toEqual([
       '/a-c-:c(e|f)',
       '/a-d-:c(e|f)',
       '/b-c-:c(e|f)',

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -302,15 +302,22 @@ describe('vueRouterToRou3', () => {
     ])
   })
 
-  it('drops non-enumerable custom regexps and keeps the dynamic param', () => {
-    expect(vueRouterToRou3('/users/:id(\\d+)')).toEqual(['/users/:id'])
-    expect(vueRouterToRou3('/articles/article-:slug([^/]+)')).toEqual(['/articles/article-:slug'])
-  })
-
   it('maps param modifiers to rou3 equivalents', () => {
     expect(vueRouterToRou3('/:id?')).toEqual(['/:id?'])
     expect(vueRouterToRou3('/:slug+')).toEqual(['/:slug+'])
     expect(vueRouterToRou3('/:pathMatch(.*)*')).toEqual(['/:pathMatch*'])
+  })
+
+  it('preserves non-enumerable custom regexps as rou3 constraints', () => {
+    expect(vueRouterToRou3('/users/:id(\\d+)')).toEqual(['/users/:id(\\d+)'])
+    expect(vueRouterToRou3('/users/:id(\\d+)?')).toEqual(['/users/:id(\\d+)?'])
+    expect(vueRouterToRou3('/articles/article-:slug([^/]+)')).toEqual(['/articles/article-:slug([^/]+)'])
+    expect(vueRouterToRou3('/repeat/:id(\\d+)+')).toEqual(['/repeat/:id+'])
+  })
+
+  it('handles escaped parentheses inside a custom regexp', () => {
+    expect(vueRouterToRou3('/:custom(a\\(b)/tail')).toEqual(['/:custom(a\\(b)/tail'])
+    expect(vueRouterToRou3('/:x(a\\')).toEqual(['/a'])
   })
 
   it('preserves plain and trailing-slash paths', () => {
@@ -325,15 +332,24 @@ describe('vueRouterToRou3', () => {
 
   it('can disable expansion', () => {
     expect(vueRouterToRou3('/:locale(de|fr)/account', { expand: false })).toEqual([
-      '/:locale/account',
+      '/:locale(de|fr)/account',
     ])
   })
 
-  it('falls back to a dynamic param when expansion would exceed the limit', () => {
+  it('falls back to a constrained param when expansion would exceed the limit', () => {
     expect(vueRouterToRou3('/:a(a|b|c)/:b(d|e|f)', { maxExpansions: 4 })).toEqual([
-      '/a/:b',
-      '/b/:b',
-      '/c/:b',
+      '/a/:b(d|e|f)',
+      '/b/:b(d|e|f)',
+      '/c/:b(d|e|f)',
+    ])
+  })
+
+  it('bounds expansion of multiple params within a single segment', () => {
+    expect(vueRouterToRou3('/:a(a|b)-:b(c|d)-:c(e|f)', { maxExpansions: 4 })).toEqual([
+      '/a-c-:c(e|f)',
+      '/a-d-:c(e|f)',
+      '/b-c-:c(e|f)',
+      '/b-d-:c(e|f)',
     ])
   })
 })

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -313,8 +313,12 @@ describe('vueRouterToRou3', () => {
   it('preserves non-enumerable custom regexps as rou3 constraints', () => {
     expect(patterns('/users/:id(\\d+)')).toEqual(['/users/:id(\\d+)'])
     expect(patterns('/users/:id(\\d+)?')).toEqual(['/users/:id(\\d+)?'])
-    expect(patterns('/articles/article-:slug([^/]+)')).toEqual(['/articles/article-:slug([^/]+)'])
     expect(patterns('/repeat/:id(\\d+)+')).toEqual(['/repeat/:id+'])
+  })
+
+  it('drops custom regexps containing a slash', () => {
+    expect(patterns('/articles/article-:slug([^/]+)')).toEqual(['/articles/article-:slug'])
+    expect(vueRouterToRou3('/articles/article-:slug([^/]+)').issues.map(issue => issue.type)).toEqual(['dropped-regexp'])
   })
 
   it('handles escaped parentheses inside a custom regexp', () => {
@@ -364,6 +368,13 @@ describe('vueRouterToRou3', () => {
     expect(issues('/de/account/verify')).toEqual([])
     expect(issues('/:locale(de|fr)/account')).toEqual([])
     expect(issues('/:locale(de|fr)/account', { collapse: true })).toEqual([])
+  })
+
+  it('rejects invalid maxExpansions values', () => {
+    expect(() => vueRouterToRou3('/x', { maxExpansions: Number.NaN })).toThrow(TypeError)
+    expect(() => vueRouterToRou3('/x', { maxExpansions: 0 })).toThrow(TypeError)
+    expect(() => vueRouterToRou3('/x', { maxExpansions: -1 })).toThrow(TypeError)
+    expect(() => vueRouterToRou3('/x', { maxExpansions: 4.5 })).toThrow(TypeError)
   })
 
   it('can disable expansion', () => {


### PR DESCRIPTION
linked https://github.com/nuxt/nuxt/pull/35455

cc: @bobbiegoede

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a helper to convert compiled Vue Router 4 `path` strings into rou3/Nitro route patterns.
  * Exposes `vueRouterToRou3` (including options/result types) from the main entrypoint.
  * Supports configurable alternation expansion, `collapse` catch-all globbing, and returns an `issues` report for lossy conversions.
* **Documentation**
  * Documented the helper API, options (`expand`, `maxExpansions`, `collapse`), and examples, including regexp/escaping behavior.
* **Tests**
  * Added unit tests covering expansion rules, escaping edge cases, modifier mapping, and `expand`/`maxExpansions`/`collapse` interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->