### PR TITLE
feat: add rou3 pattern to URLPattern converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,28 @@ interface RegExpRoute {
 }
 ```
 
+### `rou3PatternToURLPattern(pattern, options?)`
+
+Convert a single rou3/Nitro route pattern into a URLPattern pathname pattern (e.g. for a [Speculation Rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) `href_matches` rule, or `new URLPattern({ pathname })`). rou3 and URLPattern disagree on `*`/`**`, so this is not a no-op. Single-segment tokens (`:name`, `*`) map to `([^/]+)` / `([^/]*)` by default; pass `{ segment: 'loose' }` to map them to `*` (shorter, but matches across `/`).
+
+```ts
+function rou3PatternToURLPattern(pattern: string, options?: { segment?: 'strict' | 'loose' }): {
+  pattern: string
+  issues: Rou3ToURLPatternIssue[]
+}
+
+rou3PatternToURLPattern('/blog/**').pattern // => '/blog/*'
+rou3PatternToURLPattern('/users/:id').pattern // => '/users/([^/]+)'
+```
+
+Conversions are best-effort: single-segment tokens widen to `*` in loose mode, repeatable params (`:path+`) widen to a catch-all, and rou3 syntax with no URLPattern equivalent (regexp constraints, unnamed/non-capturing groups) is dropped for a broader pattern. Every such step is recorded in `issues` so callers can surface them:
+
+```ts
+const { pattern, issues } = rou3PatternToURLPattern('/users/:id(\\d+)')
+// pattern => '/users/([^/]+)'
+// issues => [{ type: 'unsupported', param: 'id', message: 'Dropped regexp constraint on ":id" ...' }]
+```
+
 ### `toVueRouterSegment(tokens, options?)`
 
 Convert a single parsed segment (an array of tokens returned by `parseSegment`) into a Vue Router 4 path segment string. Useful for modules that already have resolved routes and only need segment-level path conversion (e.g., `@nuxtjs/i18n` converting per-locale custom paths).

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ interface RegExpRoute {
 
 ### `rou3PatternToURLPattern(pattern, options?)`
 
-Convert a single rou3/Nitro route pattern into a URLPattern pathname pattern (e.g. for a [Speculation Rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) `href_matches` rule, or `new URLPattern({ pathname })`). rou3 and URLPattern disagree on `*`/`**`, so this is not a no-op. Single-segment tokens (`:name`, `*`) map to `([^/]+)` / `([^/]*)` by default; pass `{ segment: 'loose' }` to map them to `*` (shorter, but matches across `/`).
+Convert a single rou3/Nitro route pattern into a URLPattern pathname pattern (e.g. for a [Speculation Rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) `href_matches` rule, or `new URLPattern({ pathname })`). rou3 describes its syntax as URLPattern-compatible, so most tokens (`:name`, `:name(regex)`, `:name?`, `:name+`, `(regex)`, `{...}`) pass through unchanged. Only `*` and `**` genuinely differ and are translated: rou3 `*` (single segment) becomes `([^/]*)`, and rou3 `**`/`**:name` (catch-all) becomes `*`.
 
 ```ts
 function rou3PatternToURLPattern(pattern: string, options?: { segment?: 'strict' | 'loose' }): {
@@ -374,15 +374,16 @@ function rou3PatternToURLPattern(pattern: string, options?: { segment?: 'strict'
 }
 
 rou3PatternToURLPattern('/blog/**').pattern // => '/blog/*'
-rou3PatternToURLPattern('/users/:id').pattern // => '/users/([^/]+)'
+rou3PatternToURLPattern('/users/:id').pattern // => '/users/:id'
+rou3PatternToURLPattern('/users/:id(\\d+)').pattern // => '/users/:id(\\d+)'
 ```
 
-Conversions are best-effort: single-segment tokens widen to `*` in loose mode, repeatable params (`:path+`) widen to a catch-all, and rou3 syntax with no URLPattern equivalent (regexp constraints, unnamed/non-capturing groups) is dropped for a broader pattern. Every such step is recorded in `issues` so callers can surface them:
+Pass `{ segment: 'loose' }` to collapse single-segment tokens (`:name`, `*`) to `*` instead, matching Nuxt's historical inline conversion. This over-matches (a single `*` matches across `/`), so each collapse is recorded in `issues`:
 
 ```ts
-const { pattern, issues } = rou3PatternToURLPattern('/users/:id(\\d+)')
-// pattern => '/users/([^/]+)'
-// issues => [{ type: 'unsupported', param: 'id', message: 'Dropped regexp constraint on ":id" ...' }]
+const { pattern, issues } = rou3PatternToURLPattern('/users/:id', { segment: 'loose' })
+// pattern => '/users/*'
+// issues => [{ type: 'widened', param: 'id', message: 'Widened ":id" ...' }]
 ```
 
 ### `toVueRouterSegment(tokens, options?)`

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,6 @@ export { compileParsePath, parsePath, parseSegment } from './parse'
 
 export type { BuildTreeOptions, InputFile, RouteNode, RouteNodeFile, RouteTree } from './tree'
 export { addFile, buildTree, isPageNode, removeFile, walkTree } from './tree'
+
+export type { Rou3PatternToURLPatternOptions, Rou3PatternToURLPatternResult, Rou3ToURLPatternIssue } from './url-pattern'
+export { rou3PatternToURLPattern } from './url-pattern'

--- a/src/url-pattern.ts
+++ b/src/url-pattern.ts
@@ -1,13 +1,15 @@
 /**
  * Convert rou3 / Nitro route patterns into URLPattern pathname syntax.
  *
- * rou3 describes its own syntax as "URLPattern-compatible", but the two
- * disagree on a few tokens, so the conversion is not a no-op:
+ * rou3 describes its own syntax as "URLPattern-compatible", and most tokens
+ * (`:name`, `:name(regex)`, `:name?`, `:name+`, `:name*`, `(regex)`, `{...}`)
+ * mean the same thing in both, so they are passed through unchanged. Only two
+ * tokens genuinely differ and are translated:
  *
- * - rou3 `*` is a single-segment wildcard (`[^/]*`, does not cross `/`).
- * - URLPattern `*` is a greedy catch-all (`.*`, crosses `/`).
- * - rou3 `**` is a catch-all (zero or more segments); URLPattern treats `**`
- *   literally.
+ * - rou3 `*` is a single-segment wildcard (`[^/]*`); URLPattern `*` is a
+ *   greedy catch-all (`.*`, crosses `/`), so rou3 `*` becomes `([^/]*)`.
+ * - rou3 `**` (and `**:name`) is a catch-all; URLPattern treats `**`
+ *   literally, so it becomes `*`.
  *
  * See rou3's "Differences from URLPattern" table:
  * https://github.com/h3js/rou3#differences-from-urlpattern
@@ -19,14 +21,12 @@
 
 export interface Rou3ToURLPatternIssue {
   /**
-   * - `widened`: the emitted pattern matches more than the rou3 route did,
-   *   e.g. a single-segment token mapped to `*` (which crosses `/`) under
-   *   `segment: 'loose'`, or a repeatable param.
-   * - `unsupported`: the pattern contained rou3 syntax with no faithful
-   *   URLPattern equivalent (a regexp constraint, unnamed group or
-   *   non-capturing group); a best-effort, broader pattern was emitted.
+   * `widened`: the emitted pattern matches more than the rou3 route did, e.g. a
+   * single-segment token mapped to `*` (which crosses `/`) under
+   * `segment: 'loose'`, or a repeating group (`{...}+` / `{...}*`), which rou3
+   * scopes to a single segment but URLPattern repeats across `/`.
    */
-  type: 'widened' | 'unsupported'
+  type: 'widened'
   /** The param name involved, if the issue concerns a single param. */
   param?: string
   message: string
@@ -56,17 +56,17 @@ export interface Rou3PatternToURLPatternResult {
 /**
  * Convert a single rou3 route pattern into a URLPattern pathname pattern.
  *
- * Handles the segment kinds used by rou3 route rules: static segments, named
- * params (`:name`), single-segment wildcards (`*`), catch-alls (`**`) and
- * named catch-alls (`**:name`). Backslash-escaped characters are left as-is.
+ * URLPattern-compatible tokens (named params, constrained params, modifiers,
+ * groups) are passed through unchanged; only `*` and `**` are translated (see
+ * the module doc comment). Backslash-escaped characters are left as-is.
  *
- * Any lossy or widening step is recorded in `issues` (see
- * {@link Rou3ToURLPatternIssue}), so callers can surface risky conversions to
- * their users rather than silently emitting a broader matcher.
+ * Any widening step is recorded in `issues` (see {@link Rou3ToURLPatternIssue}),
+ * so callers can surface risky conversions to their users rather than silently
+ * emitting a broader matcher.
  *
  * @example
  * rou3PatternToURLPattern('/blog/**').pattern // => '/blog/*'
- * rou3PatternToURLPattern('/users/:id').pattern // => '/users/([^/]+)'
+ * rou3PatternToURLPattern('/users/:id').pattern // => '/users/:id'
  * rou3PatternToURLPattern('/users/:id', { segment: 'loose' }).pattern // => '/users/*'
  */
 export function rou3PatternToURLPattern(
@@ -80,10 +80,13 @@ export function rou3PatternToURLPattern(
 
 const WORD_RE = /\w/
 
+function isModifier(char: string | undefined): boolean {
+  return char === '?' || char === '+' || char === '*'
+}
+
 function convert(pattern: string, loose: boolean, report: (issue: Rou3ToURLPatternIssue) => void): string {
-  const singleSegment = loose ? '*' : '([^/]+)'
   return splitRou3Segments(pattern)
-    .map(segment => convertSegment(segment, pattern, loose, singleSegment, report))
+    .map(segment => convertSegment(segment, pattern, loose, report))
     .join('/')
 }
 
@@ -91,7 +94,6 @@ function convertSegment(
   segment: string,
   pattern: string,
   loose: boolean,
-  singleSegment: string,
   report: (issue: Rou3ToURLPatternIssue) => void,
 ): string {
   let out = ''
@@ -115,62 +117,67 @@ function convertSegment(
         out += '*'
         continue
       }
-      if (loose)
+      if (loose) {
         report({ type: 'widened', message: `Widened \`*\` in "${pattern}" to \`*\`, which matches across \`/\`` })
-      out += loose ? '*' : '([^/]*)'
+        out += '*'
+      }
+      else {
+        out += '([^/]*)'
+      }
       i++
       continue
     }
 
     if (char === ':') {
+      const start = i
       i++
       let name = ''
       while (i < segment.length && WORD_RE.test(segment[i])) {
         name += segment[i]
         i++
       }
-      let constrained = false
-      if (segment[i] === '(') {
-        constrained = true
+      if (segment[i] === '(')
         i = skipGroup(segment, i)
-      }
-      const modifier = segment[i] === '?' || segment[i] === '+' || segment[i] === '*' ? segment[i++] : ''
+      if (isModifier(segment[i]))
+        i++
 
-      if (constrained)
-        report({ type: 'unsupported', param: name, message: `Dropped regexp constraint on ":${name}" in "${pattern}"; rou3 constraints have no URLPattern equivalent here` })
-
-      if (modifier === '+' || modifier === '*') {
-        report({ type: 'widened', param: name, message: `Widened repeatable param ":${name}${modifier}" in "${pattern}" to \`*\`, which matches across \`/\`` })
+      if (loose) {
+        report({ type: 'widened', param: name, message: `Widened ":${name}" in "${pattern}" to \`*\`, which matches across \`/\`` })
         out += '*'
       }
-      else if (modifier === '?') {
-        if (loose)
-          report({ type: 'widened', param: name, message: `Widened optional param ":${name}?" in "${pattern}" to \`*\`, which matches across \`/\`` })
-        out += loose ? '*' : '([^/]+)?'
-      }
       else {
-        if (loose)
-          report({ type: 'widened', param: name, message: `Widened ":${name}" in "${pattern}" to \`*\`, which matches across \`/\`` })
-        out += singleSegment
+        out += segment.slice(start, i)
       }
       continue
     }
 
     if (char === '(') {
+      const start = i
       i = skipGroup(segment, i)
-      if (segment[i] === '?' || segment[i] === '+' || segment[i] === '*')
+      if (isModifier(segment[i]))
         i++
-      report({ type: 'unsupported', message: `Dropped unnamed group in "${pattern}"; rou3 groups have no URLPattern equivalent here` })
-      out += loose ? '*' : '([^/]*)'
+      if (loose) {
+        report({ type: 'widened', message: `Widened unnamed group in "${pattern}" to \`*\`, which matches across \`/\`` })
+        out += '*'
+      }
+      else {
+        out += segment.slice(start, i)
+      }
       continue
     }
 
     if (char === '{') {
-      while (i < segment.length && segment[i] !== '}') i++
-      i++
-      if (segment[i] === '?' || segment[i] === '+' || segment[i] === '*')
+      const start = i
+      while (i < segment.length && segment[i] !== '}') {
+        if (segment[i] === '\\')
+          i++
         i++
-      report({ type: 'unsupported', message: `Dropped non-capturing group in "${pattern}"; rou3 groups have no URLPattern equivalent here` })
+      }
+      i++
+      const modifier = isModifier(segment[i]) ? segment[i++] : ''
+      out += segment.slice(start, i)
+      if (modifier === '+' || modifier === '*')
+        report({ type: 'widened', message: `Repeating group "{...}${modifier}" in "${pattern}" matches across \`/\` in URLPattern but only within a segment in rou3` })
       continue
     }
 

--- a/src/url-pattern.ts
+++ b/src/url-pattern.ts
@@ -1,0 +1,228 @@
+/**
+ * Convert rou3 / Nitro route patterns into URLPattern pathname syntax.
+ *
+ * rou3 describes its own syntax as "URLPattern-compatible", but the two
+ * disagree on a few tokens, so the conversion is not a no-op:
+ *
+ * - rou3 `*` is a single-segment wildcard (`[^/]*`, does not cross `/`).
+ * - URLPattern `*` is a greedy catch-all (`.*`, crosses `/`).
+ * - rou3 `**` is a catch-all (zero or more segments); URLPattern treats `**`
+ *   literally.
+ *
+ * See rou3's "Differences from URLPattern" table:
+ * https://github.com/h3js/rou3#differences-from-urlpattern
+ *
+ * The resulting strings are URLPattern pathname patterns, so they can be
+ * dropped straight into a Speculation Rules `href_matches` rule or passed to
+ * `new URLPattern({ pathname })`.
+ */
+
+export interface Rou3ToURLPatternIssue {
+  /**
+   * - `widened`: the emitted pattern matches more than the rou3 route did,
+   *   e.g. a single-segment token mapped to `*` (which crosses `/`) under
+   *   `segment: 'loose'`, or a repeatable param.
+   * - `unsupported`: the pattern contained rou3 syntax with no faithful
+   *   URLPattern equivalent (a regexp constraint, unnamed group or
+   *   non-capturing group); a best-effort, broader pattern was emitted.
+   */
+  type: 'widened' | 'unsupported'
+  /** The param name involved, if the issue concerns a single param. */
+  param?: string
+  message: string
+}
+
+export interface Rou3PatternToURLPatternOptions {
+  /**
+   * How to translate a single-segment token (rou3 `:name` and bare `*`).
+   *
+   * - `'strict'` (default): map to `([^/]+)` / `([^/]*)` so the pattern does
+   *   not match across `/`, preserving rou3's segment-scoped semantics.
+   * - `'loose'`: map to URLPattern `*`, matching Nuxt's historical inline
+   *   conversion. This over-matches (a single `*` will also match nested
+   *   paths) and is reported as a `widened` issue, but produces shorter
+   *   patterns.
+   */
+  segment?: 'strict' | 'loose'
+}
+
+export interface Rou3PatternToURLPatternResult {
+  /** The converted URLPattern pathname pattern. */
+  pattern: string
+  /** One entry per lossy or widening conversion step; empty when faithful. */
+  issues: Rou3ToURLPatternIssue[]
+}
+
+/**
+ * Convert a single rou3 route pattern into a URLPattern pathname pattern.
+ *
+ * Handles the segment kinds used by rou3 route rules: static segments, named
+ * params (`:name`), single-segment wildcards (`*`), catch-alls (`**`) and
+ * named catch-alls (`**:name`). Backslash-escaped characters are left as-is.
+ *
+ * Any lossy or widening step is recorded in `issues` (see
+ * {@link Rou3ToURLPatternIssue}), so callers can surface risky conversions to
+ * their users rather than silently emitting a broader matcher.
+ *
+ * @example
+ * rou3PatternToURLPattern('/blog/**').pattern // => '/blog/*'
+ * rou3PatternToURLPattern('/users/:id').pattern // => '/users/([^/]+)'
+ * rou3PatternToURLPattern('/users/:id', { segment: 'loose' }).pattern // => '/users/*'
+ */
+export function rou3PatternToURLPattern(
+  pattern: string,
+  options?: Rou3PatternToURLPatternOptions,
+): Rou3PatternToURLPatternResult {
+  const issues: Rou3ToURLPatternIssue[] = []
+  const converted = convert(pattern, options?.segment === 'loose', issue => issues.push(issue))
+  return { pattern: converted, issues }
+}
+
+const WORD_RE = /\w/
+
+function convert(pattern: string, loose: boolean, report: (issue: Rou3ToURLPatternIssue) => void): string {
+  const singleSegment = loose ? '*' : '([^/]+)'
+  return splitRou3Segments(pattern)
+    .map(segment => convertSegment(segment, pattern, loose, singleSegment, report))
+    .join('/')
+}
+
+function convertSegment(
+  segment: string,
+  pattern: string,
+  loose: boolean,
+  singleSegment: string,
+  report: (issue: Rou3ToURLPatternIssue) => void,
+): string {
+  let out = ''
+  let i = 0
+  while (i < segment.length) {
+    const char = segment[i]
+
+    if (char === '\\') {
+      out += char + (segment[i + 1] ?? '')
+      i += 2
+      continue
+    }
+
+    if (char === '*') {
+      if (segment[i + 1] === '*') {
+        i += 2
+        if (segment[i] === ':') {
+          i++
+          while (i < segment.length && WORD_RE.test(segment[i])) i++
+        }
+        out += '*'
+        continue
+      }
+      if (loose)
+        report({ type: 'widened', message: `Widened \`*\` in "${pattern}" to \`*\`, which matches across \`/\`` })
+      out += loose ? '*' : '([^/]*)'
+      i++
+      continue
+    }
+
+    if (char === ':') {
+      i++
+      let name = ''
+      while (i < segment.length && WORD_RE.test(segment[i])) {
+        name += segment[i]
+        i++
+      }
+      let constrained = false
+      if (segment[i] === '(') {
+        constrained = true
+        i = skipGroup(segment, i)
+      }
+      const modifier = segment[i] === '?' || segment[i] === '+' || segment[i] === '*' ? segment[i++] : ''
+
+      if (constrained)
+        report({ type: 'unsupported', param: name, message: `Dropped regexp constraint on ":${name}" in "${pattern}"; rou3 constraints have no URLPattern equivalent here` })
+
+      if (modifier === '+' || modifier === '*') {
+        report({ type: 'widened', param: name, message: `Widened repeatable param ":${name}${modifier}" in "${pattern}" to \`*\`, which matches across \`/\`` })
+        out += '*'
+      }
+      else if (modifier === '?') {
+        if (loose)
+          report({ type: 'widened', param: name, message: `Widened optional param ":${name}?" in "${pattern}" to \`*\`, which matches across \`/\`` })
+        out += loose ? '*' : '([^/]+)?'
+      }
+      else {
+        if (loose)
+          report({ type: 'widened', param: name, message: `Widened ":${name}" in "${pattern}" to \`*\`, which matches across \`/\`` })
+        out += singleSegment
+      }
+      continue
+    }
+
+    if (char === '(') {
+      i = skipGroup(segment, i)
+      if (segment[i] === '?' || segment[i] === '+' || segment[i] === '*')
+        i++
+      report({ type: 'unsupported', message: `Dropped unnamed group in "${pattern}"; rou3 groups have no URLPattern equivalent here` })
+      out += loose ? '*' : '([^/]*)'
+      continue
+    }
+
+    if (char === '{') {
+      while (i < segment.length && segment[i] !== '}') i++
+      i++
+      if (segment[i] === '?' || segment[i] === '+' || segment[i] === '*')
+        i++
+      report({ type: 'unsupported', message: `Dropped non-capturing group in "${pattern}"; rou3 groups have no URLPattern equivalent here` })
+      continue
+    }
+
+    out += char
+    i++
+  }
+  return out
+}
+
+/** Split a rou3 pattern on unescaped `/`. */
+function splitRou3Segments(pattern: string): string[] {
+  const segments: string[] = []
+  let current = ''
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i]
+    if (char === '\\') {
+      current += char + (pattern[i + 1] ?? '')
+      i++
+      continue
+    }
+    if (char === '/') {
+      segments.push(current)
+      current = ''
+      continue
+    }
+    current += char
+  }
+  segments.push(current)
+  return segments
+}
+
+/** Return the index just past a `(...)` group starting at `open`. */
+function skipGroup(segment: string, open: number): number {
+  let depth = 0
+  let i = open
+  while (i < segment.length) {
+    const char = segment[i]
+    if (char === '\\') {
+      i += 2
+      continue
+    }
+    if (char === '(') {
+      depth++
+    }
+    else if (char === ')') {
+      depth--
+      i++
+      if (depth === 0)
+        return i
+      continue
+    }
+    i++
+  }
+  return i
+}

--- a/test/unit/url-pattern.spec.ts
+++ b/test/unit/url-pattern.spec.ts
@@ -10,35 +10,49 @@ describe('rou3PatternToURLPattern', () => {
     expect(convert('/foo/bar')).toBe('/foo/bar')
   })
 
-  it('converts named params to a single segment', () => {
-    expect(convert('/users/:id')).toBe('/users/([^/]+)')
-    expect(convert('/users/:id/posts/:slug')).toBe('/users/([^/]+)/posts/([^/]+)')
+  it('passes named params through unchanged', () => {
+    expect(convert('/users/:id')).toBe('/users/:id')
+    expect(convert('/users/:id/posts/:slug')).toBe('/users/:id/posts/:slug')
   })
 
-  it('converts single-segment wildcards', () => {
+  it('passes constrained params through unchanged', () => {
+    expect(convert('/users/:id(\\d+)')).toBe('/users/:id(\\d+)')
+    expect(convert('/files/:ext(png|jpg)')).toBe('/files/:ext(png|jpg)')
+  })
+
+  it('passes param modifiers through unchanged', () => {
+    expect(convert('/users/:id?')).toBe('/users/:id?')
+    expect(convert('/files/:path+')).toBe('/files/:path+')
+    expect(convert('/files/:path*')).toBe('/files/:path*')
+  })
+
+  it('passes unnamed and non-capturing groups through unchanged', () => {
+    expect(convert('/path/(\\d+)')).toBe('/path/(\\d+)')
+    expect(convert('/path/(\\d+)?')).toBe('/path/(\\d+)?')
+    expect(convert('/book{s}?')).toBe('/book{s}?')
+  })
+
+  it('preserves nested and escaped syntax inside groups', () => {
+    expect(convert('/users/:id((a)b)')).toBe('/users/:id((a)b)')
+    expect(convert('/foo{a\\}b}')).toBe('/foo{a\\}b}')
+  })
+
+  it('tolerates an unterminated constraint group', () => {
+    expect(convert('/users/:id(unterminated')).toBe('/users/:id(unterminated')
+  })
+
+  it('translates single-segment wildcards', () => {
     expect(convert('/files/*')).toBe('/files/([^/]*)')
     expect(convert('/files/*.png')).toBe('/files/([^/]*).png')
   })
 
-  it('converts catch-alls to URLPattern greedy wildcard', () => {
+  it('translates catch-alls to URLPattern greedy wildcard', () => {
     expect(convert('/blog/**')).toBe('/blog/*')
-  })
-
-  it('converts named catch-alls', () => {
     expect(convert('/blog/**:rest')).toBe('/blog/*')
   })
 
-  it('converts optional params', () => {
-    expect(convert('/users/:id?')).toBe('/users/([^/]+)?')
-  })
-
-  it('widens repeatable params to a catch-all', () => {
-    expect(convert('/files/:path+')).toBe('/files/*')
-    expect(convert('/files/:path*')).toBe('/files/*')
-  })
-
   it('handles a mix of segment kinds', () => {
-    expect(convert('/api/:v/users/*/**')).toBe('/api/([^/]+)/users/([^/]*)/*')
+    expect(convert('/api/:v/users/*/**')).toBe('/api/:v/users/([^/]*)/*')
   })
 
   it('leaves escaped tokens as literals', () => {
@@ -49,14 +63,11 @@ describe('rou3PatternToURLPattern', () => {
     expect(convert('/foo\\')).toBe('/foo\\')
   })
 
-  it('drops a non-capturing group with no modifier', () => {
-    expect(convert('/book{s}')).toBe('/book')
-  })
-
   it('supports loose (Nuxt-style) segment mapping', () => {
     expect(convert('/users/:id', 'loose')).toBe('/users/*')
     expect(convert('/files/*', 'loose')).toBe('/files/*')
     expect(convert('/blog/**:rest', 'loose')).toBe('/blog/*')
+    expect(convert('/path/(\\d+)', 'loose')).toBe('/path/*')
   })
 
   it('matches the historical Nuxt inline conversion in loose mode', () => {
@@ -73,66 +84,30 @@ describe('rou3PatternToURLPattern', () => {
     it('is empty for a faithful conversion', () => {
       expect(rou3PatternToURLPattern('/blog/**').issues).toEqual([])
       expect(rou3PatternToURLPattern('/users/:id').issues).toEqual([])
+      expect(rou3PatternToURLPattern('/users/:id(\\d+)').issues).toEqual([])
+      expect(rou3PatternToURLPattern('/files/:path+').issues).toEqual([])
     })
 
-    it('reports widening in loose mode', () => {
+    it('reports the widening of a named param in loose mode', () => {
       const { issues } = rou3PatternToURLPattern('/users/:id', { segment: 'loose' })
-      expect(issues).toHaveLength(1)
-      expect(issues[0]).toMatchObject({ type: 'widened', param: 'id' })
-    })
-
-    it('reports widening for repeatable params', () => {
-      const { pattern, issues } = rou3PatternToURLPattern('/files/:path+')
-      expect(pattern).toBe('/files/*')
-      expect(issues).toMatchObject([{ type: 'widened', param: 'path' }])
-    })
-
-    it('reports dropped regexp constraints', () => {
-      const { pattern, issues } = rou3PatternToURLPattern('/users/:id(\\d+)')
-      expect(pattern).toBe('/users/([^/]+)')
-      expect(issues).toMatchObject([{ type: 'unsupported', param: 'id' }])
-    })
-
-    it('reports widening for optional params in loose mode', () => {
-      const { pattern, issues } = rou3PatternToURLPattern('/users/:id?', { segment: 'loose' })
-      expect(pattern).toBe('/users/*')
       expect(issues).toMatchObject([{ type: 'widened', param: 'id' }])
     })
 
-    it('reports unnamed groups', () => {
-      const { pattern, issues } = rou3PatternToURLPattern('/path/(\\d+)')
-      expect(pattern).toBe('/path/([^/]*)')
-      expect(issues).toMatchObject([{ type: 'unsupported' }])
+    it('reports the widening of a single-segment wildcard in loose mode', () => {
+      const { issues } = rou3PatternToURLPattern('/files/*', { segment: 'loose' })
+      expect(issues).toMatchObject([{ type: 'widened' }])
     })
 
-    it('widens unnamed groups to `*` in loose mode', () => {
+    it('reports the widening of an unnamed group in loose mode', () => {
       const { pattern, issues } = rou3PatternToURLPattern('/path/(\\d+)', { segment: 'loose' })
       expect(pattern).toBe('/path/*')
-      expect(issues).toMatchObject([{ type: 'unsupported' }])
+      expect(issues).toMatchObject([{ type: 'widened' }])
     })
 
-    it('reports unnamed groups carrying a modifier', () => {
-      const { pattern, issues } = rou3PatternToURLPattern('/path/(\\d+)?')
-      expect(pattern).toBe('/path/([^/]*)')
-      expect(issues).toMatchObject([{ type: 'unsupported' }])
-    })
-
-    it('tolerates an unterminated constraint group', () => {
-      const { pattern, issues } = rou3PatternToURLPattern('/users/:id(unterminated')
-      expect(pattern).toBe('/users/([^/]+)')
-      expect(issues).toMatchObject([{ type: 'unsupported', param: 'id' }])
-    })
-
-    it('skips over nested and escaped parens in a constraint body', () => {
-      const { pattern, issues } = rou3PatternToURLPattern('/users/:id(\\(a(b)\\))')
-      expect(pattern).toBe('/users/([^/]+)')
-      expect(issues).toMatchObject([{ type: 'unsupported', param: 'id' }])
-    })
-
-    it('reports non-capturing groups', () => {
-      const { pattern, issues } = rou3PatternToURLPattern('/book{s}?')
-      expect(pattern).toBe('/book')
-      expect(issues).toMatchObject([{ type: 'unsupported' }])
+    it('reports repeating groups whose cross-segment semantics differ', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/book{s}+')
+      expect(pattern).toBe('/book{s}+')
+      expect(issues).toMatchObject([{ type: 'widened' }])
     })
   })
 })

--- a/test/unit/url-pattern.spec.ts
+++ b/test/unit/url-pattern.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { rou3PatternToURLPattern } from '../../src'
+
+function convert(pattern: string, segment?: 'strict' | 'loose') {
+  return rou3PatternToURLPattern(pattern, segment ? { segment } : undefined).pattern
+}
+
+describe('rou3PatternToURLPattern', () => {
+  it('leaves static segments untouched', () => {
+    expect(convert('/foo/bar')).toBe('/foo/bar')
+  })
+
+  it('converts named params to a single segment', () => {
+    expect(convert('/users/:id')).toBe('/users/([^/]+)')
+    expect(convert('/users/:id/posts/:slug')).toBe('/users/([^/]+)/posts/([^/]+)')
+  })
+
+  it('converts single-segment wildcards', () => {
+    expect(convert('/files/*')).toBe('/files/([^/]*)')
+    expect(convert('/files/*.png')).toBe('/files/([^/]*).png')
+  })
+
+  it('converts catch-alls to URLPattern greedy wildcard', () => {
+    expect(convert('/blog/**')).toBe('/blog/*')
+  })
+
+  it('converts named catch-alls', () => {
+    expect(convert('/blog/**:rest')).toBe('/blog/*')
+  })
+
+  it('converts optional params', () => {
+    expect(convert('/users/:id?')).toBe('/users/([^/]+)?')
+  })
+
+  it('widens repeatable params to a catch-all', () => {
+    expect(convert('/files/:path+')).toBe('/files/*')
+    expect(convert('/files/:path*')).toBe('/files/*')
+  })
+
+  it('handles a mix of segment kinds', () => {
+    expect(convert('/api/:v/users/*/**')).toBe('/api/([^/]+)/users/([^/]*)/*')
+  })
+
+  it('leaves escaped tokens as literals', () => {
+    expect(convert('/static\\:path/\\*')).toBe('/static\\:path/\\*')
+  })
+
+  it('tolerates a trailing backslash', () => {
+    expect(convert('/foo\\')).toBe('/foo\\')
+  })
+
+  it('drops a non-capturing group with no modifier', () => {
+    expect(convert('/book{s}')).toBe('/book')
+  })
+
+  it('supports loose (Nuxt-style) segment mapping', () => {
+    expect(convert('/users/:id', 'loose')).toBe('/users/*')
+    expect(convert('/files/*', 'loose')).toBe('/files/*')
+    expect(convert('/blog/**:rest', 'loose')).toBe('/blog/*')
+  })
+
+  it('matches the historical Nuxt inline conversion in loose mode', () => {
+    const nuxtInline = (route: string) => route
+      .replace(/\*\*:\w+/g, '*')
+      .replace(/\*\*/g, '*')
+      .replace(/:\w+/g, '*')
+    for (const route of ['/blog/**', '/blog/**:rest', '/users/:id', '/a/:b/**:c']) {
+      expect(convert(route, 'loose')).toBe(nuxtInline(route))
+    }
+  })
+
+  describe('issues', () => {
+    it('is empty for a faithful conversion', () => {
+      expect(rou3PatternToURLPattern('/blog/**').issues).toEqual([])
+      expect(rou3PatternToURLPattern('/users/:id').issues).toEqual([])
+    })
+
+    it('reports widening in loose mode', () => {
+      const { issues } = rou3PatternToURLPattern('/users/:id', { segment: 'loose' })
+      expect(issues).toHaveLength(1)
+      expect(issues[0]).toMatchObject({ type: 'widened', param: 'id' })
+    })
+
+    it('reports widening for repeatable params', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/files/:path+')
+      expect(pattern).toBe('/files/*')
+      expect(issues).toMatchObject([{ type: 'widened', param: 'path' }])
+    })
+
+    it('reports dropped regexp constraints', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/users/:id(\\d+)')
+      expect(pattern).toBe('/users/([^/]+)')
+      expect(issues).toMatchObject([{ type: 'unsupported', param: 'id' }])
+    })
+
+    it('reports widening for optional params in loose mode', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/users/:id?', { segment: 'loose' })
+      expect(pattern).toBe('/users/*')
+      expect(issues).toMatchObject([{ type: 'widened', param: 'id' }])
+    })
+
+    it('reports unnamed groups', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/path/(\\d+)')
+      expect(pattern).toBe('/path/([^/]*)')
+      expect(issues).toMatchObject([{ type: 'unsupported' }])
+    })
+
+    it('widens unnamed groups to `*` in loose mode', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/path/(\\d+)', { segment: 'loose' })
+      expect(pattern).toBe('/path/*')
+      expect(issues).toMatchObject([{ type: 'unsupported' }])
+    })
+
+    it('reports unnamed groups carrying a modifier', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/path/(\\d+)?')
+      expect(pattern).toBe('/path/([^/]*)')
+      expect(issues).toMatchObject([{ type: 'unsupported' }])
+    })
+
+    it('tolerates an unterminated constraint group', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/users/:id(unterminated')
+      expect(pattern).toBe('/users/([^/]+)')
+      expect(issues).toMatchObject([{ type: 'unsupported', param: 'id' }])
+    })
+
+    it('skips over nested and escaped parens in a constraint body', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/users/:id(\\(a(b)\\))')
+      expect(pattern).toBe('/users/([^/]+)')
+      expect(issues).toMatchObject([{ type: 'unsupported', param: 'id' }])
+    })
+
+    it('reports non-capturing groups', () => {
+      const { pattern, issues } = rou3PatternToURLPattern('/book{s}?')
+      expect(pattern).toBe('/book')
+      expect(issues).toMatchObject([{ type: 'unsupported' }])
+    })
+  })
+})


### PR DESCRIPTION
this is for https://github.com/nuxt/nuxt/issues/35768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helpers to convert rou3/Nitro route patterns into Speculation Rules `href_matches` patterns.
  * Added support for strict and loose segment matching.
  * Added utilities to generate deduplicated patterns from route rules, with optional filtering.
  * Exported the new helpers and their configuration types.

* **Documentation**
  * Documented the new APIs and usage options in the README.

* **Tests**
  * Added coverage for wildcards, named parameters, escaped tokens, deduplication, and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->