### PR TITLE
fix: parse `[[...slug]]` optional catch-alls

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -168,6 +168,7 @@ export function parseSegment(segment: string, absolutePath?: string, warn?: (mes
   let state: State = 'initial'
   let i = 0
   let buffer = ''
+  let optionalCatchall = false
   const tokens: ParsedPathSegmentToken[] = []
 
   function flush(type: SegmentType) {
@@ -213,12 +214,13 @@ export function parseSegment(segment: string, absolutePath?: string, warn?: (mes
       case 'group':
         if (buffer === '...') {
           buffer = ''
+          optionalCatchall = state === 'optional'
           state = 'catchall'
         }
         if (c === '[' && state === 'dynamic')
           state = 'optional'
 
-        if (c === ']' && (state !== 'optional' || segment[i - 1] === ']')) {
+        if (c === ']' && ((state !== 'optional' && !optionalCatchall) || segment[i - 1] === ']')) {
           if (!buffer)
             throw new Error('Empty param')
 
@@ -233,6 +235,7 @@ export function parseSegment(segment: string, absolutePath?: string, warn?: (mes
           else {
             flush(state)
           }
+          optionalCatchall = false
           state = 'initial'
         }
         else if (c === ')' && state === 'group') {

--- a/test/unit/parse.spec.ts
+++ b/test/unit/parse.spec.ts
@@ -61,6 +61,21 @@ describe('parsing vue file paths', () => {
     `)
   })
 
+  it('parses optional catch-all segments as catchall tokens', () => {
+    expect(parseSegment('[[...slug]]')).toEqual([
+      { type: 'catchall', value: 'slug' },
+    ])
+    expect(parseSegment('[...slug]')).toEqual([
+      { type: 'catchall', value: 'slug' },
+    ])
+    const [result] = parsePath(['b/[id]/[[...slug]].vue'])
+    expect(result.segments).toEqual([
+      [{ type: 'static', value: 'b' }],
+      [{ type: 'dynamic', value: 'id' }],
+      [{ type: 'catchall', value: 'slug' }],
+    ])
+  })
+
   it('should handle group tokens in parsing', () => {
     const [pure, mixed] = parsePath(['(group).vue', '(group)[slug].vue'])
     expect(pure.segments[0]).toEqual([


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/35804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing for optional catch-all route segments.
  * Ensured optional and non-optional catch-all syntax is recognized correctly, including paths combining dynamic and catch-all segments.

* **Tests**
  * Added coverage for optional catch-all route parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->