### PR TITLE
fix: match vue-router path encoding for static segments

### DIFF
--- a/src/converters.ts
+++ b/src/converters.ts
@@ -2,7 +2,7 @@ import type { ParsedPathSegment, ParsedPathSegmentToken } from './parse'
 import type { RouteNodeFile, RouteTree } from './tree'
 
 import escapeStringRegexp from 'escape-string-regexp'
-import { encodePath, joinURL } from 'ufo'
+import { joinURL } from 'ufo'
 
 const collator = new Intl.Collator('en-US')
 
@@ -853,7 +853,7 @@ export function toVueRouterSegment(
       case 'group':
         continue
       case 'static':
-        out += encodePath(token.value).replace(/:/g, '\\:')
+        out += encodeVueRouterPath(token.value).replace(/:/g, '\\:')
         break
 
       case 'dynamic':
@@ -1008,6 +1008,30 @@ function prepareRoutes(
 
     return out
   })
+}
+
+const ENC_PIPE_RE = /%7C/g
+const ENC_BRACKET_OPEN_RE = /%5B/g
+const ENC_BRACKET_CLOSE_RE = /%5D/g
+const ENC_ENC_SLASH_RE = /%252F/gi
+const HASH_RE = /#/g
+const QUESTION_MARK_RE = /\?/g
+
+/**
+ * Encode a static path segment the way Vue Router encodes paths, so that the
+ * emitted record matches the `location.pathname` a browser reports. Vue Router
+ * leaves `&`, `+`, `[` and `]` literal where ufo's `encodePath` escapes them.
+ *
+ * `%2F` survives unescaped, so a filename can still express an encoded slash.
+ */
+function encodeVueRouterPath(value: string): string {
+  return encodeURI(value)
+    .replace(ENC_PIPE_RE, '|')
+    .replace(ENC_BRACKET_OPEN_RE, '[')
+    .replace(ENC_BRACKET_CLOSE_RE, ']')
+    .replace(HASH_RE, '%23')
+    .replace(QUESTION_MARK_RE, '%3F')
+    .replace(ENC_ENC_SLASH_RE, '%2F')
 }
 
 /** Unescaped colon = dynamic param marker in vue-router path format. */

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -1323,18 +1323,32 @@ describe('static segment encoding', () => {
     expect(toVueRouterSegment([{ type: 'static', value: 'a%2Fb' }])).toBe('a%2Fb')
   })
 
+  it('escapes hash and question mark so they are not read as delimiters', () => {
+    expect(toVueRouterSegment([{ type: 'static', value: 'a#b' }])).toBe('a%23b')
+    expect(toVueRouterSegment([{ type: 'static', value: 'a?b' }])).toBe('a%3Fb')
+  })
+
   it('escapes colons after encoding', () => {
     expect(toVueRouterSegment([{ type: 'static', value: 'a:b&c' }])).toBe('a\\:b&c')
   })
 
-  it('matches the browser pathname in a real router', () => {
-    for (const value of ['a&b', 'a+b', 'a[b]', 'a b', 'ç']) {
-      const router = createVueRouter({
-        history: createMemoryHistory(),
-        routes: [{ path: `/${toVueRouterSegment([{ type: 'static', value }])}`, component: () => ({}) }],
-      })
-      expect(router.resolve(`/${browserEncode(value)}`).matched).toHaveLength(1)
-    }
+  it.each([
+    ['a&b', '/a&b'],
+    ['a+b', '/a+b'],
+    ['a[b]', '/a[b]'],
+    ['a b', '/a%20b'],
+    ['ç', '/%C3%A7'],
+    ['a%2Fb', '/a%2Fb'],
+    // `new URL()` splits these off as hash/search, so the expected URL is given
+    // rather than derived from `browserEncode`.
+    ['a#b', '/a%23b'],
+    ['a?b', '/a%3Fb'],
+  ])('matches a request for %s in a real router', (value, url) => {
+    const router = createVueRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: `/${toVueRouterSegment([{ type: 'static', value }])}`, component: () => ({}) }],
+    })
+    expect(router.resolve(url).matched).toHaveLength(1)
   })
 })
 

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -1298,6 +1298,46 @@ describe('toVueRouterSegment', () => {
   })
 })
 
+describe('static segment encoding', () => {
+  /** How a browser reports the segment in `location.pathname`. */
+  const browserEncode = (segment: string) => new URL(`/${segment}`, 'http://localhost').pathname.slice(1)
+
+  it.each([
+    ['a&b', 'a&b'],
+    ['a+b', 'a+b'],
+    ['a[b]', 'a[b]'],
+    ['a b', 'a%20b'],
+    ['ç', '%C3%A7'],
+    ['a|b', 'a|b'],
+  ])('encodes %s as vue-router and the browser do', (value, expected) => {
+    expect(toVueRouterSegment([{ type: 'static', value }])).toBe(expected)
+    expect(browserEncode(value)).toBe(expected)
+  })
+
+  it('escapes a literal percent sign', () => {
+    expect(toVueRouterSegment([{ type: 'static', value: '100%' }])).toBe('100%25')
+    expect(toVueRouterSegment([{ type: 'static', value: 'a%25b' }])).toBe('a%2525b')
+  })
+
+  it('passes through an encoded slash', () => {
+    expect(toVueRouterSegment([{ type: 'static', value: 'a%2Fb' }])).toBe('a%2Fb')
+  })
+
+  it('escapes colons after encoding', () => {
+    expect(toVueRouterSegment([{ type: 'static', value: 'a:b&c' }])).toBe('a\\:b&c')
+  })
+
+  it('matches the browser pathname in a real router', () => {
+    for (const value of ['a&b', 'a+b', 'a[b]', 'a b', 'ç']) {
+      const router = createVueRouter({
+        history: createMemoryHistory(),
+        routes: [{ path: `/${toVueRouterSegment([{ type: 'static', value }])}`, component: () => ({}) }],
+      })
+      expect(router.resolve(`/${browserEncode(value)}`).matched).toHaveLength(1)
+    }
+  })
+})
+
 describe('toVueRouterPath', () => {
   it('converts single-segment paths', () => {
     const parsed = parsePath(['about.vue'])[0]

--- a/test/unit/nuxt-compat.spec.ts
+++ b/test/unit/nuxt-compat.spec.ts
@@ -213,7 +213,7 @@ describe('nuxt compatibility: generateRoutes from files', () => {
       `${pagesDir}/a&b.vue`,
       `${pagesDir}/a\\b.vue`,
     ]), [
-      { name: 'a&b', path: `/a${encodeURIComponent('&')}b`, file: `${pagesDir}/a&b.vue`, children: [] },
+      { name: 'a&b', path: '/a&b', file: `${pagesDir}/a&b.vue`, children: [] },
       { name: 'a\\b', path: `/a${encodeURIComponent('\\')}b`, file: `${pagesDir}/a\\b.vue`, children: [] },
     ])
   })


### PR DESCRIPTION
`encodePath` from `ufo` doesn't match `vue-router`, so we were unwittingly emitting paths that would not be matched as expected with the router.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static route path encoding for better Vue Router and browser compatibility.
  * Correctly handles spaces, Unicode characters, percent signs, encoded slashes, hashes, question marks, and colons.
  * Preserves supported characters such as ampersands in generated paths.

* **Tests**
  * Added coverage for route-segment encoding and browser-compatible paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->