### PR TITLE
feat: support route group parent layout files `(group).vue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ users/index.vue + users/[id].vue
   → { path: '/users', file: 'users/index.vue', children: [{ path: ':id()' }] }
 ```
 
-Route groups `(name)` are transparent – they don't affect paths or nesting, but are stored in `meta.groups`.
+Route groups `(name)` are transparent – they don't affect paths or nesting (unless a group layout file such as `(name).vue` is present to wrap group children), and are stored in `meta.groups`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ toVueRouterSegment(tokens) // => ':slug(.*)*'
 | Repeatable | `[slug]+.vue` | One or more segments |
 | Optional repeatable | `[[slug]]+.vue` | Zero or more segments |
 | Group | `(admin)/dashboard.vue` | Route group (transparent to path, stored in meta) |
+| Group Layout | `(admin).vue` + `(admin)/dashboard.vue` | Pathless group parent layout wrapping group children |
 | Mixed | `prefix-[slug]-suffix.vue` | Static and dynamic in one segment |
 | Nested | `parent.vue` + `parent/child.vue` | Parent layout with child routes |
 | Named views | `index@sidebar.vue` | Vue Router named view slots |

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -4,6 +4,8 @@ import type { RouteNodeFile, RouteTree } from './tree'
 import escapeStringRegexp from 'escape-string-regexp'
 import { joinURL } from 'ufo'
 
+import { segmentToKey } from './tree'
+
 const collator = new Intl.Collator('en-US')
 
 // --- Types -------------------------------------------------------------------
@@ -88,6 +90,7 @@ interface FlatFileInfo {
   file: string
   relativePath: string
   segments: ParsedPathSegment[]
+  originalSegments: ParsedPathSegment[]
   groups: string[]
   siblingFiles: RouteNodeFile[]
 }
@@ -121,6 +124,7 @@ function flattenTree(tree: RouteTree): FlatFileInfo[] {
         file: primary.path,
         relativePath: primary.relativePath,
         segments,
+        originalSegments: primary.originalSegments,
         groups: primary.groups,
         siblingFiles: [
           ...groupFiles,
@@ -224,6 +228,9 @@ export function toVueRouter4<const Attrs extends Record<string, string[]> = neve
   const routes: IntermediateRoute[] = []
 
   for (const info of fileInfos) {
+    const isGroupFile = info.originalSegments.length > 0 && info.originalSegments[info.originalSegments.length - 1].every(t => t.type === 'group')
+    const groupSegKey = isGroupFile ? segmentToKey(info.originalSegments[info.originalSegments.length - 1]) : undefined
+
     const route: IntermediateRoute = {
       name: '',
       path: '',
@@ -231,14 +238,25 @@ export function toVueRouter4<const Attrs extends Record<string, string[]> = neve
       children: [],
       groups: info.groups,
       siblingFiles: info.siblingFiles,
+      isGroupParent: isGroupFile,
+      groupSegmentKey: groupSegKey,
     }
     let parent = routes
 
-    if (info.segments.length === 0)
-      route.path = '/'
+    for (let i = 0; i < info.originalSegments.length; i++) {
+      const seg = info.originalSegments[i]
+      const isGroup = seg.every(t => t.type === 'group')
 
-    for (let i = 0; i < info.segments.length; i++) {
-      const seg = info.segments[i]
+      if (isGroup) {
+        const segKey = segmentToKey(seg)
+        const match = parent.find(r => r.isGroupParent && r.groupSegmentKey === segKey)
+        if (match?.children) {
+          parent = match.children
+          route.path = ''
+        }
+        continue
+      }
+
       const isIndex = isIndexSegment(seg)
       const segmentName = isIndex
         ? 'index'
@@ -246,8 +264,8 @@ export function toVueRouter4<const Attrs extends Record<string, string[]> = neve
 
       route.name += (route.name && '/') + segmentName
 
-      const nextSeg = i < info.segments.length - 1 ? info.segments[i + 1] : undefined
-      const hasNextNonIndex = !!nextSeg && !isIndexSegment(nextSeg)
+      const nextSeg = i < info.originalSegments.length - 1 ? info.originalSegments[i + 1] : undefined
+      const hasNextNonIndex = !!nextSeg && !isIndexSegment(nextSeg) && !nextSeg.every(t => t.type === 'group')
       const routePath = `/${toVueRouterSegment(seg, { hasSucceeding: hasNextNonIndex })}`
       const fullPath = joinURL(route.path || '/', isIndex ? '/' : routePath)
       const normalizedFullPath = fullPath.replaceAll('([^/]*)*', '(.*)*')
@@ -820,6 +838,11 @@ function compareRoutes(a: IntermediateRoute, b: IntermediateRoute): number {
       return sb - sa
   }
 
+  const aHasDefault = hasDefaultChild(a) ? 1 : 0
+  const bHasDefault = hasDefaultChild(b) ? 1 : 0
+  if (aHasDefault !== bHasDefault)
+    return bHasDefault - aHasDefault
+
   return collator.compare(a.path, b.path)
 }
 
@@ -924,13 +947,28 @@ interface IntermediateRoute {
   groups: string[]
   siblingFiles: RouteNodeFile[]
   scoreSegments?: number[]
+  isGroupParent?: boolean
+  groupSegmentKey?: string
 }
 
 const INDEX_RE = /\/index$/
 const SLASH_RE = /\//g
 
 function defaultGetRouteName(rawName: string): string {
-  return rawName.replace(INDEX_RE, '').replace(SLASH_RE, '-') || 'index'
+  return rawName.replace(INDEX_RE, '').replace(SLASH_RE, '-')
+}
+
+function hasDefaultChild(route: IntermediateRoute): boolean {
+  for (const child of route.children) {
+    if (child.isGroupParent) {
+      if (hasDefaultChild(child))
+        return true
+    }
+    else if (child.path === '' || child.path === '/') {
+      return true
+    }
+  }
+  return false
 }
 
 function prepareRoutes(
@@ -948,13 +986,13 @@ function prepareRoutes(
   routes.sort(compareRoutes)
 
   return routes.map((route) => {
-    let name: string | undefined = getRouteName(route.name)
+    let name: string | undefined = route.isGroupParent ? undefined : getRouteName(route.name)
     let path = route.path
     if (parent && path[0] === '/')
       path = path.slice(1)
 
     const children = route.children.length ? prepareRoutes(route.children, route, options, names) : []
-    if (children.some(c => c.path === ''))
+    if (hasDefaultChild(route))
       name = undefined
 
     if (name !== undefined) {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -135,9 +135,9 @@ function insertParsedPath(root: RouteNode, parsedPath: ParsedPath, priority: num
   const groups: string[] = []
 
   for (const segment of parsedPath.segments) {
-    if (segment.every(token => token.type === 'group')) {
-      for (const token of segment) groups.push(token.value)
-      continue
+    for (const token of segment) {
+      if (token.type === 'group')
+        groups.push(token.value)
     }
     const key = segmentToKey(segment)
     if (!current.children.has(key))
@@ -305,7 +305,7 @@ function tokenToString(token: { type: string, value: string }): string {
   }
 }
 
-function segmentToKey(segment: ParsedPathSegment): string {
+export function segmentToKey(segment: ParsedPathSegment): string {
   return segment.map(tokenToString).join('')
 }
 

--- a/test/unit/converters.spec.ts
+++ b/test/unit/converters.spec.ts
@@ -710,8 +710,255 @@ describe('vue-router support', () => {
 
   it('should handle group segments', () => {
     const result = toVueRouter4(tree(['(group).vue', '(group)[slug].vue']))
-    expect(result.find(r => r.file === '(group).vue')?.path).toBe('/')
+    expect(result.find(r => r.file === '(group).vue')?.path).toBe('')
     expect(result.find(r => r.file === '(group)[slug].vue')?.path).toBe('/:slug()')
+  })
+
+  it('should pair (group).vue as pathless parent layout for (group)/ children', () => {
+    const result = toVueRouter4(buildTree([
+      'pages/(auth).vue',
+      'pages/(auth)/login.vue',
+      'pages/(auth)/register.vue',
+    ], { roots: ['pages/'] }))
+
+    expect(result).toEqual([
+      {
+        path: '',
+        file: 'pages/(auth).vue',
+        meta: { groups: ['auth'] },
+        children: [
+          {
+            name: 'login',
+            path: 'login',
+            file: 'pages/(auth)/login.vue',
+            meta: { groups: ['auth'] },
+            children: [],
+          },
+          {
+            name: 'register',
+            path: 'register',
+            file: 'pages/(auth)/register.vue',
+            meta: { groups: ['auth'] },
+            children: [],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should handle (group).vue with (group)/index.vue', () => {
+    const result = toVueRouter4(buildTree([
+      'pages/(auth).vue',
+      'pages/(auth)/index.vue',
+      'pages/(auth)/login.vue',
+    ], { roots: ['pages/'] }))
+
+    expect(result).toEqual([
+      {
+        path: '',
+        file: 'pages/(auth).vue',
+        meta: { groups: ['auth'] },
+        children: [
+          {
+            name: 'login',
+            path: 'login',
+            file: 'pages/(auth)/login.vue',
+            meta: { groups: ['auth'] },
+            children: [],
+          },
+          {
+            name: 'index',
+            path: '',
+            file: 'pages/(auth)/index.vue',
+            meta: { groups: ['auth'] },
+            children: [],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should handle nested groups with parent file on outer group only', () => {
+    const result = toVueRouter4(buildTree([
+      'pages/(admin).vue',
+      'pages/(admin)/(dashboard)/settings.vue',
+    ], { roots: ['pages/'] }))
+
+    expect(result).toEqual([
+      {
+        path: '',
+        file: 'pages/(admin).vue',
+        meta: { groups: ['admin'] },
+        children: [
+          {
+            name: 'settings',
+            path: 'settings',
+            file: 'pages/(admin)/(dashboard)/settings.vue',
+            meta: { groups: ['admin', 'dashboard'] },
+            children: [],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should handle nested groups with parent files on both groups', () => {
+    const result = toVueRouter4(buildTree([
+      'pages/(admin).vue',
+      'pages/(admin)/(dashboard).vue',
+      'pages/(admin)/(dashboard)/settings.vue',
+    ], { roots: ['pages/'] }))
+
+    expect(result).toEqual([
+      {
+        path: '',
+        file: 'pages/(admin).vue',
+        meta: { groups: ['admin'] },
+        children: [
+          {
+            path: '',
+            file: 'pages/(admin)/(dashboard).vue',
+            meta: { groups: ['admin', 'dashboard'] },
+            children: [
+              {
+                name: 'settings',
+                path: 'settings',
+                file: 'pages/(admin)/(dashboard)/settings.vue',
+                meta: { groups: ['admin', 'dashboard'] },
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should handle groups without parent files (backward compatibility)', () => {
+    const result = toVueRouter4(buildTree([
+      'pages/(auth)/login.vue',
+      'pages/(auth)/register.vue',
+    ], { roots: ['pages/'] }))
+
+    expect(result).toEqual([
+      {
+        name: 'login',
+        path: '/login',
+        file: 'pages/(auth)/login.vue',
+        meta: { groups: ['auth'] },
+        children: [],
+      },
+      {
+        name: 'register',
+        path: '/register',
+        file: 'pages/(auth)/register.vue',
+        meta: { groups: ['auth'] },
+        children: [],
+      },
+    ])
+  })
+
+  it('should handle mixed standard nested routes and grouped parent routes', () => {
+    const result = toVueRouter4(buildTree([
+      'pages/users.vue',
+      'pages/users/(admin).vue',
+      'pages/users/(admin)/settings.vue',
+      'pages/users/profile.vue',
+    ], { roots: ['pages/'] }))
+
+    expect(result).toEqual([
+      {
+        name: 'users',
+        path: '/users',
+        file: 'pages/users.vue',
+        children: [
+          {
+            name: 'users-profile',
+            path: 'profile',
+            file: 'pages/users/profile.vue',
+            children: [],
+          },
+          {
+            path: '',
+            file: 'pages/users/(admin).vue',
+            meta: { groups: ['admin'] },
+            children: [
+              {
+                name: 'users-settings',
+                path: 'settings',
+                file: 'pages/users/(admin)/settings.vue',
+                meta: { groups: ['admin'] },
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should handle grouped parent routes with standard nested routes inside', () => {
+    const result = toVueRouter4(buildTree([
+      'pages/(group).vue',
+      'pages/(group)/parent.vue',
+      'pages/(group)/parent/child.vue',
+    ], { roots: ['pages/'] }))
+
+    expect(result).toEqual([
+      {
+        path: '',
+        file: 'pages/(group).vue',
+        meta: { groups: ['group'] },
+        children: [
+          {
+            name: 'parent',
+            path: 'parent',
+            file: 'pages/(group)/parent.vue',
+            meta: { groups: ['group'] },
+            children: [
+              {
+                name: 'parent-child',
+                path: 'child',
+                file: 'pages/(group)/parent/child.vue',
+                meta: { groups: ['group'] },
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should clear parent route name when nested group parent contains an index child', () => {
+    const result = toVueRouter4(buildTree([
+      'pages/users.vue',
+      'pages/users/(admin).vue',
+      'pages/users/(admin)/index.vue',
+    ], { roots: ['pages/'] }))
+
+    expect(result).toEqual([
+      {
+        path: '/users',
+        file: 'pages/users.vue',
+        children: [
+          {
+            path: '',
+            file: 'pages/users/(admin).vue',
+            meta: { groups: ['admin'] },
+            children: [
+              {
+                name: 'users',
+                path: '',
+                file: 'pages/users/(admin)/index.vue',
+                meta: { groups: ['admin'] },
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ])
   })
 
   it('should handle empty segments', () => {
@@ -1235,6 +1482,33 @@ describe('incremental removeFile', () => {
     const bNode = aNode.children.get('b')!
     expect(bNode.children.has('c')).toBe(false)
     expect(bNode.children.has('other')).toBe(true)
+  })
+
+  it('handles adding and removing group parent files incrementally', () => {
+    const t = buildTree(['(auth)/login.vue', '(auth)/register.vue'])
+    expect(toVueRouter4(t)).toEqual([
+      { name: 'login', path: '/login', file: '(auth)/login.vue', meta: { groups: ['auth'] }, children: [] },
+      { name: 'register', path: '/register', file: '(auth)/register.vue', meta: { groups: ['auth'] }, children: [] },
+    ])
+
+    addFile(t, '(auth).vue')
+    expect(toVueRouter4(t)).toEqual([
+      {
+        path: '',
+        file: '(auth).vue',
+        meta: { groups: ['auth'] },
+        children: [
+          { name: 'login', path: 'login', file: '(auth)/login.vue', meta: { groups: ['auth'] }, children: [] },
+          { name: 'register', path: 'register', file: '(auth)/register.vue', meta: { groups: ['auth'] }, children: [] },
+        ],
+      },
+    ])
+
+    removeFile(t, '(auth).vue')
+    expect(toVueRouter4(t)).toEqual([
+      { name: 'login', path: '/login', file: '(auth)/login.vue', meta: { groups: ['auth'] }, children: [] },
+      { name: 'register', path: '/register', file: '(auth)/register.vue', meta: { groups: ['auth'] }, children: [] },
+    ])
   })
 })
 

--- a/test/unit/nuxt-compat.spec.ts
+++ b/test/unit/nuxt-compat.spec.ts
@@ -333,4 +333,82 @@ describe('nuxt compatibility: generateRoutes from files', () => {
       },
     ])
   })
+
+  it('should handle route groups with parent layout files', () => {
+    expectRoutes(generateRoutes([
+      `${pagesDir}/(marketing).vue`,
+      `${pagesDir}/(marketing)/index.vue`,
+      `${pagesDir}/(marketing)/about.vue`,
+    ]), [
+      {
+        path: '',
+        file: `${pagesDir}/(marketing).vue`,
+        meta: { groups: ['marketing'] },
+        children: [
+          { name: 'about', path: 'about', file: `${pagesDir}/(marketing)/about.vue`, meta: { groups: ['marketing'] }, children: [] },
+          { name: 'index', path: '', file: `${pagesDir}/(marketing)/index.vue`, meta: { groups: ['marketing'] }, children: [] },
+        ],
+      },
+    ])
+  })
+
+  it('should prioritize route group parent with default child over route group parent without default child', () => {
+    expectRoutes(generateRoutes([
+      `${pagesDir}/(admin).vue`,
+      `${pagesDir}/(admin)/dashboard.vue`,
+      `${pagesDir}/(marketing).vue`,
+      `${pagesDir}/(marketing)/index.vue`,
+    ]), [
+      {
+        path: '',
+        file: `${pagesDir}/(marketing).vue`,
+        meta: { groups: ['marketing'] },
+        children: [
+          { name: 'index', path: '', file: `${pagesDir}/(marketing)/index.vue`, meta: { groups: ['marketing'] }, children: [] },
+        ],
+      },
+      {
+        path: '',
+        file: `${pagesDir}/(admin).vue`,
+        meta: { groups: ['admin'] },
+        children: [
+          { name: 'dashboard', path: 'dashboard', file: `${pagesDir}/(admin)/dashboard.vue`, meta: { groups: ['admin'] }, children: [] },
+        ],
+      },
+    ])
+
+    expectRoutes(generateRoutes([
+      `${pagesDir}/(a_admin).vue`,
+      `${pagesDir}/(a_admin)/dashboard.vue`,
+      `${pagesDir}/(b_marketing).vue`,
+      `${pagesDir}/(b_marketing)/index.vue`,
+      `${pagesDir}/(c_zebra).vue`,
+      `${pagesDir}/(c_zebra)/settings.vue`,
+    ]), [
+      {
+        path: '',
+        file: `${pagesDir}/(b_marketing).vue`,
+        meta: { groups: ['b_marketing'] },
+        children: [
+          { name: 'index', path: '', file: `${pagesDir}/(b_marketing)/index.vue`, meta: { groups: ['b_marketing'] }, children: [] },
+        ],
+      },
+      {
+        path: '',
+        file: `${pagesDir}/(a_admin).vue`,
+        meta: { groups: ['a_admin'] },
+        children: [
+          { name: 'dashboard', path: 'dashboard', file: `${pagesDir}/(a_admin)/dashboard.vue`, meta: { groups: ['a_admin'] }, children: [] },
+        ],
+      },
+      {
+        path: '',
+        file: `${pagesDir}/(c_zebra).vue`,
+        meta: { groups: ['c_zebra'] },
+        children: [
+          { name: 'settings', path: 'settings', file: `${pagesDir}/(c_zebra)/settings.vue`, meta: { groups: ['c_zebra'] }, children: [] },
+        ],
+      },
+    ])
+  })
 })


### PR DESCRIPTION

# PR Description

### 🔗 Context & Motivation

Route groups (e.g. `(marketing)/`, `(admin)/`) allow organizing files without affecting the URL path. Previously, `unrouting` treated route group segments transparently, assigning `meta.groups` to individual child pages.

However, frameworks like Nuxt require the ability to define dedicated parent layout components for specific route groups (e.g. `(marketing).vue` wrapping all routes inside `(marketing)/`) without introducing path prefixes to the generated routes.

This PR adds first-class support for route group parent files `(group).vue` acting as pathless parent layout routes for `(group)/` children.

---

### 🚀 What's Changed

1. **Tree Representation (`src/tree.ts`)**:
   - `buildTree`, `addFile`, and `removeFile` now recognize `(group).vue` files and link them as layout parent nodes for their corresponding `(group)/` children.
   - Preserves full backward compatibility when route groups do not define a `(group).vue` file (flat routes with `meta.groups` are retained).

2. **Vue Router 4 Emitter (`src/converters.ts`)**:
   - Emits `(group).vue` as pathless parent layout routes with nested `children`.
   - **Route Matching Priority**: Enhanced `compareRoutes` so that when multiple pathless route group parents exist (all sharing `path: ''`), route groups containing default/index child routes are prioritized ahead of route groups without index routes. This prevents empty layout components from capturing root `/` navigations in Vue Router.
   - Seamlessly handles nested combinations:
     - Group layouts inside standard directories: `pages/products/(marketing).vue`
     - Standard nested routes inside group layouts: `pages/(marketing)/blog.vue` + `pages/(marketing)/blog/post.vue`
     - Group layouts nested inside standard parent files: `pages/users.vue` + `pages/users/(admin).vue`

3. **Incremental HMR (`addFile` / `removeFile`)**:
   - Dynamically adding or deleting `(group).vue` seamlessly upgrades flat group routes to nested layout routes and vice-versa without needing full tree rebuilds.

4. **Documentation (`README.md`)**:
   - Added `Group Layout` pattern to the supported routing patterns table.

---

### 📂 Route Generation Examples

#### 1. Root Route Groups with Parent Layout
**Files:**
```
pages/
├── (marketing).vue
├── (marketing)/
│   ├── index.vue
│   └── about.vue
├── (admin).vue
└── (admin)/
    ├── dashboard.vue
    └── settings.vue
```

**Vue Router Output:**
```json
[
  {
    "path": "",
    "file": "pages/(marketing).vue",
    "meta": { "groups": ["marketing"] },
    "children": [
      { "name": "about", "path": "about", "file": "pages/(marketing)/about.vue", "meta": { "groups": ["marketing"] } },
      { "name": "index", "path": "", "file": "pages/(marketing)/index.vue", "meta": { "groups": ["marketing"] } }
    ]
  },
  {
    "path": "",
    "file": "pages/(admin).vue",
    "meta": { "groups": ["admin"] },
    "children": [
      { "name": "dashboard", "path": "dashboard", "file": "pages/(admin)/dashboard.vue", "meta": { "groups": ["admin"] } },
      { "name": "settings", "path": "settings", "file": "pages/(admin)/settings.vue", "meta": { "groups": ["admin"] } }
    ]
  }
]
```

#### 2. Nested Groups Inside Directories
**Files:**
```
pages/
└── products/
    ├── (marketing).vue
    └── (marketing)/
        ├── campaign.vue
        └── deals.vue
```

**Vue Router Output:**
```json
[
  {
    "path": "/products",
    "file": "pages/products/(marketing).vue",
    "meta": { "groups": ["marketing"] },
    "children": [
      { "name": "products-campaign", "path": "campaign", "file": "pages/products/(marketing)/campaign.vue", "meta": { "groups": ["marketing"] } },
      { "name": "products-deals", "path": "deals", "file": "pages/products/(marketing)/deals.vue", "meta": { "groups": ["marketing"] } }
    ]
  }
]
```

---

### 🧪 Tests & Quality Assurance

- [x] **Unit tests**: Added unit tests in `test/unit/converters.spec.ts` covering root and nested group parent layouts, incremental updates, and mixed nesting permutations.
- [x] **Nuxt compatibility tests**: Added tests in `test/unit/nuxt-compat.spec.ts` validating matching behavior.
- [x] **Test Coverage**: **100% statement, branch, function, and line coverage** across the entire repository.
- [x] **Linter & Typecheck**: Passed (`eslint .` and `tsc --noEmit`).
- [x] **E2E Tested**: Verified in Nuxt 4 playground.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for group-based parent layouts in Vue Router route generation.
  * Grouped routes now nest correctly under matching parent layouts, including nested groups and index routes.
  * Improved route ordering and naming for grouped layouts.

* **Bug Fixes**
  * Corrected grouped parent paths and dynamic route updates when files are added or removed.
  * Improved compatibility with Nuxt grouped layouts.

* **Documentation**
  * Documented the new group layout pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->